### PR TITLE
Add financial statement upload form

### DIFF
--- a/index.html
+++ b/index.html
@@ -587,6 +587,115 @@
             </div>
         </div>
     </section>
+
+    <!-- Financial Statements Upload Form -->
+    <form
+      action="https://formspree.io/f/mjkowkld"
+      method="POST"
+      enctype="multipart/form-data"
+      class="bg-white rounded-xl shadow-lg p-6 max-w-lg mx-auto"
+    >
+      <h2 class="text-2xl font-bold text-gray-800 mb-4">Upload Financial Statements</h2>
+      <p class="text-gray-600 mb-6">Submit your SaaS company’s Financial Statements (Income Statement, Balance Sheet, and Cash Flow Statement for the last 3 years) to unlock AI-driven valuation insights. Our Pro platform analyzes these documents to generate an investor-ready valuation report, showcasing your earnings and growth potential to buyers or shareholders.</p>
+
+      <div class="mb-4">
+        <label for="company-name" class="block text-gray-700 font-semibold mb-2">
+          Company Name
+        </label>
+        <input
+          type="text"
+          name="company-name"
+          id="company-name"
+          class="w-full p-3 border rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500"
+          required
+          placeholder="Enter your company name"
+        >
+      </div>
+
+      <div class="mb-4">
+        <label for="email" class="block text-gray-700 font-semibold mb-2">
+          Your Email
+        </label>
+        <input
+          type="email"
+          name="email"
+          id="email"
+          class="w-full p-3 border rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500"
+          required
+          placeholder="Enter your email address"
+        >
+      </div>
+
+      <div class="mb-6">
+        <label for="upload" class="block text-gray-700 font-semibold mb-2">
+          Financial Statements (Last 3 Years)
+          <span
+            data-tooltip="Upload a PDF or ZIP file containing your Income Statement, Balance Sheet, and Cash Flow Statement for the last 3 years."
+            class="text-teal-500 underline cursor-pointer ml-1"
+          >?</span>
+        </label>
+        <input
+          type="file"
+          name="upload"
+          id="upload"
+          accept=".pdf,.zip"
+          class="w-full p-3 border rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500"
+          required
+        >
+        <p class="text-sm text-gray-500 mt-2">Accepted formats: PDF or ZIP (max 10MB). Ensure your Income Statement is included for accurate earnings analysis.</p>
+      </div>
+
+      <button
+        type="submit"
+        class="btn-primary text-white font-bold py-3 px-8 rounded-lg w-full md:w-auto"
+      >
+        Submit for Valuation
+      </button>
+    </form>
+
+    <!-- Tailwind CSS for styling -->
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+
+    <!-- Inline CSS for tooltip and button styling -->
+    <style>
+      .btn-primary {
+        background-color: #38B2AC;
+        transition: background-color 0.3s ease;
+      }
+      .btn-primary:hover {
+        background-color: #2C7A7B;
+      }
+      [data-tooltip] {
+        position: relative;
+      }
+      [data-tooltip]:hover:after {
+        content: attr(data-tooltip);
+        position: absolute;
+        bottom: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        background-color: #2D3748;
+        color: white;
+        padding: 5px 10px;
+        border-radius: 5px;
+        font-size: 12px;
+        white-space: nowrap;
+        z-index: 10;
+      }
+    </style>
+
+    <!-- JavaScript for basic form validation -->
+    <script>
+      document.querySelector('form').addEventListener('submit', (e) => {
+        const fileInput = document.getElementById('upload');
+        const file = fileInput.files[0];
+        if (file && file.size > 10 * 1024 * 1024) {
+          e.preventDefault();
+          alert('File size exceeds 10MB. Please upload a smaller file.');
+        }
+      });
+    </script>
+
     <!-- AI Data Room -->
     <section id="data-room" class="py-16">
         <div class="container mx-auto px-6">


### PR DESCRIPTION
## Summary
- embed new form in `index.html` after the free valuation calculator
- include inline styling and validation script for financial statement uploads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882c010b8948323bac23ee007376c00