### PR TITLE
fix: correct favicon asset paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,12 +12,12 @@
   gtag('config', 'G-772JV93TYR');
 </script>
     <link rel="icon" type="image/png" href="favicon.png">
-<link rel="icon" type="image/png" href="/http://saasvaluation.app/faivcon.png/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/http://saasvaluation.app/faivcon.png/favicon.svg" />
-<link rel="shortcut icon" href="/http://saasvaluation.app/faivcon.png/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/http://saasvaluation.app/faivcon.png/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="favicon.svg" />
+<link rel="shortcut icon" href="favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
 <meta name="apple-mobile-web-app-title" content="SaaS Val" />
-<link rel="manifest" href="/http://saasvaluation.app/faivcon.png/site.webmanifest" />
+<link rel="manifest" href="site.webmanifest" />
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="A FREE SaaS Valuation App, AI market trends, and small business sales with SaaS Valuation App.">

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -3,13 +3,13 @@
   "short_name": "SaaS Val",
   "icons": [
     {
-      "src": "/http://saasvaluation.app/faivcon.png/web-app-manifest-192x192.png",
+      "src": "web-app-manifest-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "/http://saasvaluation.app/faivcon.png/web-app-manifest-512x512.png",
+      "src": "web-app-manifest-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"


### PR DESCRIPTION
## Summary
- point favicon link tags to local images instead of broken `saasvaluation.app` paths
- update web manifest to reference local icon files

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -I http://localhost:8000/favicon-96x96.png`
- `curl -I http://localhost:8000/favicon.svg`
- `curl -I http://localhost:8000/favicon.ico`
- `curl -I http://localhost:8000/apple-touch-icon.png`
- `curl -I http://localhost:8000/site.webmanifest`


------
https://chatgpt.com/codex/tasks/task_e_689a79cdf14083239bdeb4bd0595f702