### PR TITLE
Add contact and FAQ sections and support page

### DIFF
--- a/Support.html
+++ b/Support.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Support - SaaS Valuation App</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="font-sans bg-gray-50">
+    <header class="bg-gray-800 text-white py-4">
+        <div class="container mx-auto px-6">
+            <h1 class="text-xl font-bold"><a href="index.html">SaaS Valuation App</a></h1>
+        </div>
+    </header>
+    <main class="container mx-auto px-6 py-16">
+        <h2 class="text-3xl font-bold text-gray-800 mb-4">Support</h2>
+        <p class="text-gray-700 mb-6">We're here to help. Reach out and we'll respond as soon as possible.</p>
+        <ul class="list-disc pl-5 space-y-2 text-gray-700">
+            <li>Email: <a href="mailto:support@saasvaluationapp.com" class="text-teal-600">support@saasvaluationapp.com</a></li>
+            <li>Documentation: <a href="blog.html" class="text-teal-600">Visit our resources</a></li>
+        </ul>
+    </main>
+    <footer class="bg-gray-800 text-white py-6">
+        <div class="container mx-auto px-6 text-center">
+            <p class="text-gray-400">© 2025 SaaS Valuation App. All rights reserved.</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -774,6 +774,49 @@
             </div>
         </div>
     </section>
+    <!-- FAQ Section -->
+    <section id="faq" class="py-16 bg-white">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <h2 class="text-3xl font-bold text-gray-800 mb-4">Frequently Asked Questions</h2>
+                <p class="text-lg text-gray-600 max-w-2xl mx-auto">Answers to common questions about SaaS Valuation App.</p>
+            </div>
+            <div class="max-w-3xl mx-auto space-y-8">
+                <div>
+                    <h3 class="text-xl font-semibold text-gray-800 mb-2">How accurate is the valuation?</h3>
+                    <p class="text-gray-600">Our AI uses industry benchmarks and your data to provide a range. It is a starting point and not financial advice.</p>
+                </div>
+                <div>
+                    <h3 class="text-xl font-semibold text-gray-800 mb-2">Can I export my results?</h3>
+                    <p class="text-gray-600">Yes, you can download a PDF report of your valuation to share with investors or advisors.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+    <!-- Contact Section -->
+    <section id="contact" class="py-16 bg-gray-50">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-8">
+                <h2 class="text-3xl font-bold text-gray-800 mb-4">Contact Sales</h2>
+                <p class="text-lg text-gray-600 max-w-2xl mx-auto">Have questions about our Enterprise plan? Reach out and our team will get back to you.</p>
+            </div>
+            <form action="https://formspree.io/f/mayydjvv" method="POST" class="max-w-xl mx-auto space-y-4">
+                <div>
+                    <label for="name" class="sr-only">Name</label>
+                    <input type="text" id="name" name="name" required class="w-full border rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-teal-500" placeholder="Your Name">
+                </div>
+                <div>
+                    <label for="email" class="sr-only">Email</label>
+                    <input type="email" id="email" name="_replyto" required class="w-full border rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-teal-500" placeholder="Your Email">
+                </div>
+                <div>
+                    <label for="message" class="sr-only">Message</label>
+                    <textarea id="message" name="message" rows="4" required class="w-full border rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-teal-500" placeholder="How can we help?"></textarea>
+                </div>
+                <button type="submit" class="btn-primary text-white font-bold py-3 px-6 rounded-lg">Send Message</button>
+            </form>
+        </div>
+    </section>
     <!-- Call to Action -->
     <section class="gradient-bg text-white py-16">
         <div class="container mx-auto px-6 text-center">


### PR DESCRIPTION
## Summary
- add FAQ and contact sections to homepage
- provide standalone Support page for footer link

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a7cfe8f10832393138214f501d89f