### PR TITLE
Add secure checkout notice and trust badges to payment page

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -134,7 +134,15 @@
         <!-- Payment Section -->
         <div class="text-center bg-white p-8 rounded-xl shadow-lg max-w-lg mx-auto">
           <h2 class="text-2xl font-semibold text-gray-800 mb-6">Complete Your Payment</h2>
+          <div class="flex items-center justify-center text-gray-600 mb-2">
+            <i class="fas fa-lock text-teal-500 mr-2"></i>
+            <span>Secure checkout powered by PayPal</span>
+          </div>
           <div id="paypal-container-NVJVZYW6GRKY4" class="mx-auto max-w-xs"></div>
+          <div class="flex justify-center gap-4 mt-4">
+            <img src="https://www.paypalobjects.com/webstatic/mktg/logo/pp_cc_mark_111x69.jpg" alt="PayPal accepted" class="h-8" />
+            <img src="https://img.icons8.com/color/48/000000/ssl.png" alt="SSL Secured" class="h-8" />
+          </div>
           <div id="payment-error" class="text-red-500 text-sm mt-4 hidden">
             Payment failed. Please try again or contact support.
           </div>


### PR DESCRIPTION
## Summary
- highlight secure checkout with lock icon and message near PayPal button
- show PayPal and SSL trust badges below the payment section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a7e1f79748323b0a8541d45889137