### PR TITLE
Add privacy policy notice to subscription forms

### DIFF
--- a/index.html
+++ b/index.html
@@ -814,6 +814,7 @@
                     <textarea id="message" name="message" rows="4" required class="w-full border rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-teal-500" placeholder="How can we help?"></textarea>
                 </div>
                 <button type="submit" class="btn-primary text-white font-bold py-3 px-6 rounded-lg">Send Message</button>
+                <p class="text-xs italic text-gray-500 mt-2">By subscribing, you agree to our <a href="privacy-policy.html" class="underline">Privacy Policy</a>.</p>
             </form>
         </div>
     </section>
@@ -831,13 +832,14 @@
     <div class="container mx-auto px-6 text-center">
         <h2 class="text-3xl font-bold text-gray-800 mb-4">Get SaaS Growth Insights</h2>
         <p class="text-lg text-gray-600 mb-8 max-w-xl mx-auto">Join our newsletter for exclusive tips, valuation strategies, and updates to grow your SaaS business.</p>
-        <form action="https://formspree.io/f/mjkowkld" method="POST" class="flex flex-col md:flex-row justify-center items-center gap-4 max-w-lg mx-auto">
+        <form action="https://formspree.io/f/mjkowkld" method="POST" class="flex flex-col md:flex-row md:flex-wrap justify-center items-center gap-4 max-w-lg mx-auto">
             <div class="w-full md:w-auto flex-1">
                 <label for="email" class="sr-only">Your Email</label>
                 <input type="email" name="email" id="email" class="w-full border rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-teal-500" placeholder="Enter your email" required>
                 <p id="email-error" class="text-red-500 text-sm mt-1 hidden">Please enter a valid email address.</p>
             </div>
             <button type="submit" class="btn-primary text-white font-bold py-3 px-6 rounded-lg">Get SaaS Growth Insights</button>
+            <p class="w-full text-xs italic text-gray-500 mt-2 text-center">By subscribing, you agree to our <a href="privacy-policy.html" class="underline">Privacy Policy</a>.</p>
         </form>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- Add small italicized Privacy Policy consent below contact form submit button
- Add similar Privacy Policy notice below newsletter signup and tweak layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a7f75b1fc832388def95e9f9bdade