### PR TITLE
Fix favicon and manifest paths in pro valuation page

### DIFF
--- a/pro-valuation.html
+++ b/pro-valuation.html
@@ -18,12 +18,12 @@
   <meta name="description" content="Access our advanced SaaS valuation tool for a detailed business assessment." />
   <meta name="keywords" content="SaaS valuation tool, financial analysis, business evaluation" />
   <link rel="icon" type="image/png" href="favicon.png" />
-<link rel="icon" type="image/png" href="/http://saasvaluation.app/faivcon.png/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/http://saasvaluation.app/faivcon.png/favicon.svg" />
-<link rel="shortcut icon" href="/http://saasvaluation.app/faivcon.png/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/http://saasvaluation.app/faivcon.png/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="favicon.svg" />
+<link rel="shortcut icon" href="favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
 <meta name="apple-mobile-web-app-title" content="SaaS Val" />
-<link rel="manifest" href="/http://saasvaluation.app/faivcon.png/site.webmanifest" />
+<link rel="manifest" href="site.webmanifest" />
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- use project-root relative paths for favicon and manifest links in pro-valuation.html

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a88ef68608323a45fd8c063b70c53