### PR TITLE
feat: dynamically load chart and pdf libraries

### DIFF
--- a/pro-valuation.html
+++ b/pro-valuation.html
@@ -29,8 +29,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
     <link rel="stylesheet" href="styles/pro-valuation.css">
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 </head>
 	  <!-- HEADER -->
   <header class="bg-gray-800 text-white py-3 sticky top-0 z-50 shadow-lg">

--- a/scripts/valuation.js
+++ b/scripts/valuation.js
@@ -1,6 +1,12 @@
 import { setupPDF } from './pdf.js';
 
-export function calculateValuation() {
+export async function calculateValuation() {
+  const [{ default: Chart }, jspdf] = await Promise.all([
+    import('https://cdn.jsdelivr.net/npm/chart.js'),
+    import('https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js')
+  ]);
+  window.jspdf = jspdf;
+
   const methods = Array.from(document.querySelectorAll('input[type="checkbox"]:checked')).map(input => input.value);
   const arr = parseFloat(document.getElementById('arr').value) || 0;
   const netProfit = parseFloat(document.getElementById('net-profit').value) || 0;


### PR DESCRIPTION
## Summary
- remove direct Chart.js and jsPDF script tags from `pro-valuation.html`
- dynamically import Chart.js and jsPDF in `valuation.js`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689a89b0280c83238cea34997e522c46