### PR TITLE
Add error handling and sanitization to valuation flow

### DIFF
--- a/scripts/pdf.js
+++ b/scripts/pdf.js
@@ -2,190 +2,226 @@ export function setupPDF(data) {
   const button = document.getElementById('download-report');
   if (!button) return;
 
-  button.onclick = () => {
-    const { jsPDF } = window.jspdf;
-    const doc = new jsPDF();
-    const pageWidth = doc.internal.pageSize.getWidth();
-    const margin = 15;
-    let yPos = margin;
+  button.onclick = async () => {
+    try {
+      const { jsPDF } = window.jspdf;
+      const domPurifyModule = await import('https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js');
+      const DOMPurify = domPurifyModule.default;
+      const sanitizeText = (str) => DOMPurify.sanitize(String(str));
+      const sanitizeNumber = (num) => parseFloat(num) || 0;
+      const sanitizedData = {
+        valuations: data.valuations.map(v => ({ method: sanitizeText(v.method), value: sanitizeNumber(v.value) })),
+        avgValuation: sanitizeNumber(data.avgValuation),
+        rangeLow: sanitizeNumber(data.rangeLow),
+        rangeHigh: sanitizeNumber(data.rangeHigh),
+        confidence: sanitizeNumber(data.confidence),
+        arr: sanitizeNumber(data.arr),
+        netProfit: sanitizeNumber(data.netProfit),
+        growthYoy: sanitizeNumber(data.growthYoy),
+        customerChurn: sanitizeNumber(data.customerChurn),
+        retentionRate: sanitizeNumber(data.retentionRate),
+        nps: sanitizeNumber(data.nps),
+        legalIssues: sanitizeText(data.legalIssues),
+        ipOwnership: sanitizeText(data.ipOwnership),
+        mrr: sanitizeNumber(data.mrr),
+        ltv: sanitizeNumber(data.ltv),
+        cac: sanitizeNumber(data.cac),
+        grossMargin: sanitizeNumber(data.grossMargin),
+        burnRate: sanitizeNumber(data.burnRate),
+        runway: sanitizeNumber(data.runway),
+        activeCustomers: sanitizeNumber(data.activeCustomers),
+        mau: sanitizeNumber(data.mau),
+        debtLevel: sanitizeNumber(data.debtLevel),
+        multiplier: sanitizeNumber(data.multiplier)
+      };
 
-    const addHeader = () => {
-      doc.setFillColor(56, 178, 172);
-      doc.rect(0, 0, pageWidth, 15, 'F');
-      doc.setFontSize(12);
-      doc.setTextColor(255, 255, 255);
-      doc.text('The SaaS Valuation App™', margin, 10);
-    };
+      const doc = new jsPDF();
+      const pageWidth = doc.internal.pageSize.getWidth();
+      const margin = 15;
+      let yPos = margin;
 
-    // Cover Page
-    addHeader();
-    yPos = 25;
-    doc.setFontSize(20);
-    doc.setTextColor(0, 0, 0);
-    doc.text('The SaaS Valuation App™', margin, yPos);
-    yPos += 10;
-    doc.setFontSize(16);
-    doc.text('The Official Valuation Score with Real Metrics', margin, yPos);
-    yPos += 15;
-    doc.setFontSize(12);
-    doc.setFillColor(240, 240, 240);
-    doc.rect(margin, yPos, pageWidth - 2 * margin, 40, 'F');
-    doc.setDrawColor(251, 191, 36);
-    doc.rect(margin, yPos, pageWidth - 2 * margin, 40);
-    yPos += 10;
-    doc.text(`Valuation: $${Math.round(data.avgValuation).toLocaleString()}`, margin + 5, yPos);
-    yPos += 10;
-    doc.text(`Range: $${Math.round(data.rangeLow).toLocaleString()} - $${Math.round(data.rangeHigh).toLocaleString()}`, margin + 5, yPos);
-    yPos += 10;
-    doc.text(`Confidence: ${Math.round(data.confidence)}%`, margin + 5, yPos);
-    yPos += 15;
-    doc.setFontSize(10);
-    doc.text('Generated on May 09, 2025', margin, yPos);
+      const addHeader = () => {
+        doc.setFillColor(56, 178, 172);
+        doc.rect(0, 0, pageWidth, 15, 'F');
+        doc.setFontSize(12);
+        doc.setTextColor(255, 255, 255);
+        doc.text('The SaaS Valuation App™', margin, 10);
+      };
 
-    // Valuation Details Page
-    doc.addPage();
-    addHeader();
-    yPos = 25;
-    doc.setFontSize(16);
-    doc.setTextColor(0, 0, 0);
-    doc.text('Valuation Details', margin, yPos);
-    yPos += 10;
-    data.valuations.forEach(v => {
+      // Cover Page
+      addHeader();
+      yPos = 25;
+      doc.setFontSize(20);
+      doc.setTextColor(0, 0, 0);
+      doc.text('The SaaS Valuation App™', margin, yPos);
+      yPos += 10;
+      doc.setFontSize(16);
+      doc.text('The Official Valuation Score with Real Metrics', margin, yPos);
+      yPos += 15;
       doc.setFontSize(12);
       doc.setFillColor(240, 240, 240);
-      doc.rect(margin, yPos, pageWidth - 2 * margin, 50, 'F');
+      doc.rect(margin, yPos, pageWidth - 2 * margin, 40, 'F');
       doc.setDrawColor(251, 191, 36);
-      doc.rect(margin, yPos, pageWidth - 2 * margin, 50);
+      doc.rect(margin, yPos, pageWidth - 2 * margin, 40);
       yPos += 10;
-      doc.text(`${v.method}: $${Math.round(v.value).toLocaleString()}`, margin + 5, yPos);
-      doc.setFontSize(10);
-      yPos += 8;
-      if (v.method === 'Revenue Multiplier') {
-        doc.text(`Why: Multiplies ARR ($${data.arr.toLocaleString()}) by ${data.multiplier}x, reflecting revenue stability.`, margin + 5, yPos);
-        yPos += 5;
-        doc.text(`Improve: Increase ARR via customer acquisition or upselling; reduce churn (${data.customerChurn}%).`, margin + 5, yPos);
-        yPos += 5;
-        doc.text(`Risk: High churn or low growth (${data.growthYoy}%) lowers multiplier.`, margin + 5, yPos);
-        yPos += 5;
-        doc.text('Means: Signals revenue potential to investors.', margin + 5, yPos);
-      } else if (v.method === 'Income-Based') {
-        doc.text(`Why: Multiplies profit ($${data.netProfit.toLocaleString()}) by ${data.multiplier - 1}x, showing profitability.`, margin + 5, yPos);
-        yPos += 5;
-        doc.text(`Improve: Boost margins (${data.grossMargin}%) or cut costs (burn: $${data.burnRate.toLocaleString()}).`, margin + 5, yPos);
-        yPos += 5;
-        doc.text(`Risk: Low profit or short runway (${data.runway} months) reduces value.`, margin + 5, yPos);
-        yPos += 5;
-        doc.text('Means: Highlights cash flow for buyers.', margin + 5, yPos);
-      } else if (v.method === 'Earnings-Based') {
-        doc.text(`Why: Combines ARR ($${data.arr.toLocaleString()}) and profit, adjusted for retention (${data.retentionRate}%).`, margin + 5, yPos);
-        yPos += 5;
-        doc.text(`Improve: Enhance retention or NPS (${data.nps}); grow revenue.`, margin + 5, yPos);
-        yPos += 5;
-        doc.text('Risk: Weak customer metrics lower valuation.', margin + 5, yPos);
-        yPos += 5;
-        doc.text('Means: Balances growth and profit for investors.', margin + 5, yPos);
-      } else if (v.method === 'DCF') {
-        doc.text(`Why: Discounts cash flow ($${Math.round(data.netProfit * 1.2).toLocaleString()}) at 10%, factoring risks.`, margin + 5, yPos);
-        yPos += 5;
-        doc.text(`Improve: Extend runway (${data.runway} months) or reduce risks (e.g., legal: ${data.legalIssues}).`, margin + 5, yPos);
-        yPos += 5;
-        doc.text(`Risk: High debt ($${data.debtLevel.toLocaleString()}) or legal issues hurt value.`, margin + 5, yPos);
-        yPos += 5;
-        doc.text('Means: Shows long-term potential to buyers.', margin + 5, yPos);
-      }
+      doc.text(`Valuation: $${Math.round(sanitizedData.avgValuation).toLocaleString()}`, margin + 5, yPos);
       yPos += 10;
-    });
-
-    // Metrics Overview Page
-    doc.addPage();
-    addHeader();
-    yPos = 25;
-    doc.setFontSize(16);
-    doc.text('Key Metrics Overview', margin, yPos);
-    yPos += 10;
-    const metrics = [
-      { label: 'ARR', value: `$${data.arr.toLocaleString()}`, insight: data.arr > 1000000 ? 'Strong revenue base.' : 'Grow revenue to boost value.' },
-      { label: 'MRR', value: `$${data.mrr.toLocaleString()}`, insight: data.mrr > 100000 ? 'Stable monthly income.' : 'Increase subscriptions.' },
-      { label: 'LTV', value: `$${data.ltv.toLocaleString()}`, insight: data.ltv > 3 * data.cac ? 'High customer value.' : 'Extend customer lifetime.' },
-      { label: 'CAC', value: `$${data.cac.toLocaleString()}`, insight: data.cac < data.ltv / 3 ? 'Efficient acquisition.' : 'Lower acquisition costs.' },
-      { label: 'Gross Margin', value: `${data.grossMargin}%`, insight: data.grossMargin > 70 ? 'Efficient operations.' : 'Optimize costs.' },
-      { label: 'Net Profit', value: `$${data.netProfit.toLocaleString()}`, insight: data.netProfit > 0 ? 'Profitable business.' : 'Focus on profitability.' },
-      { label: 'Burn Rate', value: `$${data.burnRate.toLocaleString()}`, insight: data.burnRate < data.mrr ? 'Sustainable spending.' : 'Reduce expenses.' },
-      { label: 'Runway', value: `${data.runway} months`, insight: data.runway > 12 ? 'Long-term stability.' : 'Secure funding.' },
-      { label: 'YoY Growth', value: `${data.growthYoy}%`, insight: data.growthYoy > 20 ? 'Strong growth.' : 'Accelerate revenue growth.' },
-      { label: 'Customer Churn', value: `${data.customerChurn}%`, insight: data.customerChurn < 5 ? 'Loyal customers.' : 'Improve retention.' },
-      { label: 'Active Customers', value: data.activeCustomers, insight: data.activeCustomers > 1000 ? 'Large customer base.' : 'Expand customer pool.' },
-      { label: 'MAU', value: data.mau, insight: data.mau > 1000 ? 'High engagement.' : 'Increase user activity.' },
-      { label: 'NPS', value: data.nps, insight: data.nps > 50 ? 'Satisfied customers.' : 'Enhance customer experience.' },
-      { label: 'Debt Level', value: `$${data.debtLevel.toLocaleString()}`, insight: data.debtLevel < 100000 ? 'Low financial risk.' : 'Reduce debt.' }
-    ];
-    metrics.forEach(m => {
-      doc.setFontSize(12);
-      doc.setFillColor(240, 240, 240);
-      doc.rect(margin, yPos, pageWidth - 2 * margin, 15, 'F');
-      doc.setDrawColor(251, 191, 36);
-      doc.rect(margin, yPos, pageWidth - 2 * margin, 15);
-      doc.text(`${m.label}: ${m.value}`, margin + 5, yPos + 5);
+      doc.text(`Range: $${Math.round(sanitizedData.rangeLow).toLocaleString()} - $${Math.round(sanitizedData.rangeHigh).toLocaleString()}`, margin + 5, yPos);
+      yPos += 10;
+      doc.text(`Confidence: ${Math.round(sanitizedData.confidence)}%`, margin + 5, yPos);
+      yPos += 15;
       doc.setFontSize(10);
-      doc.text(m.insight, margin + 5, yPos + 12);
-      yPos += 20;
-      if (yPos > 250) {
-        doc.addPage();
-        addHeader();
-        yPos = 25;
-      }
-    });
+      doc.text('Generated on May 09, 2025', margin, yPos);
 
-    // Graphs Pages
-    const graphs = [
-      { id: 'valuation-chart', title: 'Valuation by Method', desc: 'Shows valuation per selected method.' },
-      { id: 'financial-chart', title: 'Financial Metrics Impact', desc: 'Highlights key financial inputs.' },
-      { id: 'growth-churn-chart', title: 'Growth vs. Churn', desc: 'Compares growth and churn rates.' },
-      { id: 'risk-chart', title: 'Risk Factors', desc: 'Visualizes key risk metrics.' }
-    ];
-    graphs.forEach((graph, index) => {
-      if (index % 2 === 0) {
-        doc.addPage();
-        addHeader();
-        yPos = 25;
-      }
-      const canvas = document.getElementById(graph.id);
-      const imgData = canvas.toDataURL('image/png');
-      doc.setFontSize(14);
-      doc.text(graph.title, margin, yPos);
-      yPos += 8;
+      // Valuation Details Page
+      doc.addPage();
+      addHeader();
+      yPos = 25;
+      doc.setFontSize(16);
+      doc.setTextColor(0, 0, 0);
+      doc.text('Valuation Details', margin, yPos);
+      yPos += 10;
+      sanitizedData.valuations.forEach(v => {
+        doc.setFontSize(12);
+        doc.setFillColor(240, 240, 240);
+        doc.rect(margin, yPos, pageWidth - 2 * margin, 50, 'F');
+        doc.setDrawColor(251, 191, 36);
+        doc.rect(margin, yPos, pageWidth - 2 * margin, 50);
+        yPos += 10;
+        doc.text(`${v.method}: $${Math.round(v.value).toLocaleString()}`, margin + 5, yPos);
+        doc.setFontSize(10);
+        yPos += 8;
+        if (v.method === 'Revenue Multiplier') {
+          doc.text(`Why: Multiplies ARR ($${sanitizedData.arr.toLocaleString()}) by ${sanitizedData.multiplier}x, reflecting revenue stability.`, margin + 5, yPos);
+          yPos += 5;
+          doc.text(`Improve: Increase ARR via customer acquisition or upselling; reduce churn (${sanitizedData.customerChurn}%).`, margin + 5, yPos);
+          yPos += 5;
+          doc.text(`Risk: High churn or low growth (${sanitizedData.growthYoy}%) lowers multiplier.`, margin + 5, yPos);
+          yPos += 5;
+          doc.text('Means: Signals revenue potential to investors.', margin + 5, yPos);
+        } else if (v.method === 'Income-Based') {
+          doc.text(`Why: Multiplies profit ($${sanitizedData.netProfit.toLocaleString()}) by ${sanitizedData.multiplier - 1}x, showing profitability.`, margin + 5, yPos);
+          yPos += 5;
+          doc.text(`Improve: Boost margins (${sanitizedData.grossMargin}%) or cut costs (burn: $${sanitizedData.burnRate.toLocaleString()}).`, margin + 5, yPos);
+          yPos += 5;
+          doc.text(`Risk: Low profit or short runway (${sanitizedData.runway} months) reduces value.`, margin + 5, yPos);
+          yPos += 5;
+          doc.text('Means: Highlights cash flow for buyers.', margin + 5, yPos);
+        } else if (v.method === 'Earnings-Based') {
+          doc.text(`Why: Combines ARR ($${sanitizedData.arr.toLocaleString()}) and profit, adjusted for retention (${sanitizedData.retentionRate}%).`, margin + 5, yPos);
+          yPos += 5;
+          doc.text(`Improve: Enhance retention or NPS (${sanitizedData.nps}); grow revenue.`, margin + 5, yPos);
+          yPos += 5;
+          doc.text('Risk: Weak customer metrics lower valuation.', margin + 5, yPos);
+          yPos += 5;
+          doc.text('Means: Balances growth and profit for investors.', margin + 5, yPos);
+        } else if (v.method === 'DCF') {
+          doc.text(`Why: Discounts cash flow ($${Math.round(sanitizedData.netProfit * 1.2).toLocaleString()}) at 10%, factoring risks.`, margin + 5, yPos);
+          yPos += 5;
+          doc.text(`Improve: Extend runway (${sanitizedData.runway} months) or reduce risks (e.g., legal: ${sanitizedData.legalIssues}).`, margin +5, yPos);
+          yPos += 5;
+          doc.text(`Risk: High debt ($${sanitizedData.debtLevel.toLocaleString()}) or legal issues hurt value.`, margin + 5, yPos);
+          yPos += 5;
+          doc.text('Means: Shows long-term potential to buyers.', margin + 5, yPos);
+        }
+        yPos += 10;
+      });
+
+      // Metrics Overview Page
+      doc.addPage();
+      addHeader();
+      yPos = 25;
+      doc.setFontSize(16);
+      doc.text('Key Metrics Overview', margin, yPos);
+      yPos += 10;
+      const metrics = [
+        { label: 'ARR', value: `$${sanitizedData.arr.toLocaleString()}`, insight: sanitizedData.arr > 1000000 ? 'Strong revenue base.' : 'Grow revenue to boost value.' },
+        { label: 'MRR', value: `$${sanitizedData.mrr.toLocaleString()}`, insight: sanitizedData.mrr > 100000 ? 'Stable monthly income.' : 'Increase subscriptions.' },
+        { label: 'LTV', value: `$${sanitizedData.ltv.toLocaleString()}`, insight: sanitizedData.ltv > 3 * sanitizedData.cac ? 'High customer value.' : 'Extend customer lifetime.' },
+        { label: 'CAC', value: `$${sanitizedData.cac.toLocaleString()}`, insight: sanitizedData.cac < sanitizedData.ltv / 3 ? 'Efficient acquisition.' : 'Lower acquisition costs.' },
+        { label: 'Gross Margin', value: `${sanitizedData.grossMargin}%`, insight: sanitizedData.grossMargin > 70 ? 'Efficient operations.' : 'Optimize costs.' },
+        { label: 'Net Profit', value: `$${sanitizedData.netProfit.toLocaleString()}`, insight: sanitizedData.netProfit > 0 ? 'Profitable business.' : 'Focus on profitability.' },
+        { label: 'Burn Rate', value: `$${sanitizedData.burnRate.toLocaleString()}`, insight: sanitizedData.burnRate < sanitizedData.mrr ? 'Sustainable spending.' : 'Reduce expenses.' },
+        { label: 'Runway', value: `${sanitizedData.runway} months`, insight: sanitizedData.runway > 12 ? 'Long-term stability.' : 'Secure funding.'},
+        { label: 'YoY Growth', value: `${sanitizedData.growthYoy}%`, insight: sanitizedData.growthYoy > 20 ? 'Strong growth.' : 'Accelerate revenue growth.' },
+        { label: 'Customer Churn', value: `${sanitizedData.customerChurn}%`, insight: sanitizedData.customerChurn < 5 ? 'Loyal customers.' : 'Improve retention.' },
+        { label: 'Active Customers', value: sanitizedData.activeCustomers, insight: sanitizedData.activeCustomers > 1000 ? 'Large customer base.' : 'Expand customer pool.' },
+        { label: 'MAU', value: sanitizedData.mau, insight: sanitizedData.mau > 1000 ? 'High engagement.' : 'Increase user activity.' },
+        { label: 'NPS', value: sanitizedData.nps, insight: sanitizedData.nps > 50 ? 'Satisfied customers.' : 'Enhance customer experience.' },
+        { label: 'Debt Level', value: `$${sanitizedData.debtLevel.toLocaleString()}`, insight: sanitizedData.debtLevel < 100000 ? 'Low financial risk.' : 'Reduce debt.' }
+      ];
+      metrics.forEach(m => {
+        doc.setFontSize(12);
+        doc.setFillColor(240, 240, 240);
+        doc.rect(margin, yPos, pageWidth - 2 * margin, 15, 'F');
+        doc.setDrawColor(251, 191, 36);
+        doc.rect(margin, yPos, pageWidth - 2 * margin, 15);
+        doc.text(`${m.label}: ${m.value}`, margin + 5, yPos + 5);
+        doc.setFontSize(10);
+        doc.text(m.insight, margin + 5, yPos + 12);
+        yPos += 20;
+        if (yPos > 250) {
+          doc.addPage();
+          addHeader();
+          yPos = 25;
+        }
+      });
+
+      // Graphs Pages
+      const graphs = [
+        { id: 'valuation-chart', title: 'Valuation by Method', desc: 'Shows valuation per selected method.' },
+        { id: 'financial-chart', title: 'Financial Metrics Impact', desc: 'Highlights key financial inputs.' },
+        { id: 'growth-churn-chart', title: 'Growth vs. Churn', desc: 'Compares growth and churn rates.' },
+        { id: 'risk-chart', title: 'Risk Factors', desc: 'Visualizes key risk metrics.' }
+      ];
+      graphs.forEach((graph, index) => {
+        if (index % 2 === 0) {
+          doc.addPage();
+          addHeader();
+          yPos = 25;
+        }
+        const canvas = document.getElementById(graph.id);
+        const imgData = canvas.toDataURL('image/png');
+        doc.setFontSize(14);
+        doc.text(graph.title, margin, yPos);
+        yPos += 8;
+        doc.setFontSize(10);
+        doc.text(graph.desc, margin, yPos);
+        yPos += 8;
+        doc.addImage(imgData, 'PNG', margin, yPos, 80, 50);
+        yPos += 60;
+      });
+
+      // About & Disclaimer Page
+      doc.addPage();
+      addHeader();
+      yPos = 25;
+      doc.setFontSize(16);
+      doc.text('About The SaaS Valuation App™', margin, yPos);
+      yPos += 10;
       doc.setFontSize(10);
-      doc.text(graph.desc, margin, yPos);
-      yPos += 8;
-      doc.addImage(imgData, 'PNG', margin, yPos, 80, 50);
-      yPos += 60;
-    });
+      const aboutText = 'The SaaS Valuation App™ empowers businesses with AI-driven, transparent valuations. We value honest opinions and real calculations to help investors, partners, and buyers make informed decisions without speculation. Our mission is to deliver accurate, data-driven insights based on your inputs. Contact us: support@saasvaluation.app | Visit: www.saasvaluation.app';
+      doc.text(doc.splitTextToSize(aboutText, pageWidth - 2 * margin), margin, yPos);
+      yPos += 40;
+      doc.setFontSize(16);
+      doc.text('Why Trust Us', margin, yPos);
+      yPos += 10;
+      doc.setFontSize(10);
+      const trustText = 'Our valuations are built on industry-standard methods and real-time data analysis. We prioritize transparency, ensuring every calculation is clear and actionable. Note: The accuracy of this report depends on the data you provide. Always verify inputs for reliable results.';
+      doc.text(doc.splitTextToSize(trustText, pageWidth - 2 * margin), margin, yPos);
+      yPos += 30;
+      doc.setFontSize(16);
+      doc.text('Disclaimer', margin, yPos);
+      yPos += 10;
+      doc.setFontSize(10);
+      const disclaimerText = 'This valuation is an estimate based on user-provided data and standard methods. It is not financial advice. Consult a professional advisor for business decisions. The SaaS Valuation App™ is not liable for actions taken based on this report. Accuracy depends on the correctness of your inputs.';
+      doc.text(doc.splitTextToSize(disclaimerText, pageWidth - 2 * margin), margin, yPos);
 
-    // About & Disclaimer Page
-    doc.addPage();
-    addHeader();
-    yPos = 25;
-    doc.setFontSize(16);
-    doc.text('About The SaaS Valuation App™', margin, yPos);
-    yPos += 10;
-    doc.setFontSize(10);
-    const aboutText = 'The SaaS Valuation App™ empowers businesses with AI-driven, transparent valuations. We value honest opinions and real calculations to help investors, partners, and buyers make informed decisions without speculation. Our mission is to deliver accurate, data-driven insights based on your inputs. Contact us: support@saasvaluation.app | Visit: www.saasvaluation.app';
-    doc.text(doc.splitTextToSize(aboutText, pageWidth - 2 * margin), margin, yPos);
-    yPos += 40;
-    doc.setFontSize(16);
-    doc.text('Why Trust Us', margin, yPos);
-    yPos += 10;
-    doc.setFontSize(10);
-    const trustText = 'Our valuations are built on industry-standard methods and real-time data analysis. We prioritize transparency, ensuring every calculation is clear and actionable. Note: The accuracy of this report depends on the data you provide. Always verify inputs for reliable results.';
-    doc.text(doc.splitTextToSize(trustText, pageWidth - 2 * margin), margin, yPos);
-    yPos += 30;
-    doc.setFontSize(16);
-    doc.text('Disclaimer', margin, yPos);
-    yPos += 10;
-    doc.setFontSize(10);
-    const disclaimerText = 'This valuation is an estimate based on user-provided data and standard methods. It is not financial advice. Consult a professional advisor for business decisions. The SaaS Valuation App™ is not liable for actions taken based on this report. Accuracy depends on the correctness of your inputs.';
-    doc.text(doc.splitTextToSize(disclaimerText, pageWidth - 2 * margin), margin, yPos);
-
-    doc.save('saas_valuation_report.pdf');
+      doc.save('saas_valuation_report.pdf');
+    } catch (error) {
+      console.error('Error generating PDF:', error);
+      alert('An error occurred while generating the PDF. Please try again.');
+    }
   };
 }
+

--- a/scripts/valuation.js
+++ b/scripts/valuation.js
@@ -1,157 +1,162 @@
 import { setupPDF } from './pdf.js';
 
 export async function calculateValuation() {
-  const [{ default: Chart }, jspdf] = await Promise.all([
-    import('https://cdn.jsdelivr.net/npm/chart.js'),
-    import('https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js')
-  ]);
-  window.jspdf = jspdf;
+  try {
+    const [{ default: Chart }, jspdf] = await Promise.all([
+      import('https://cdn.jsdelivr.net/npm/chart.js'),
+      import('https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js')
+    ]);
+    window.jspdf = jspdf;
 
-  const methods = Array.from(document.querySelectorAll('input[type="checkbox"]:checked')).map(input => input.value);
-  const arr = parseFloat(document.getElementById('arr').value) || 0;
-  const netProfit = parseFloat(document.getElementById('net-profit').value) || 0;
-  const growthYoy = parseFloat(document.getElementById('revenue-growth-yoy').value) || 0;
-  const customerChurn = parseFloat(document.getElementById('customer-churn').value) || 0;
-  const retentionRate = parseFloat(document.getElementById('retention-rate').value) || 0;
-  const nps = parseFloat(document.getElementById('nps').value) || 0;
-  const legalIssues = document.getElementById('legal-issues').value;
-  const ipOwnership = document.getElementById('ip-ownership').value;
-  const mrr = parseFloat(document.getElementById('mrr').value) || 0;
-  const ltv = parseFloat(document.getElementById('ltv').value) || 0;
-  const cac = parseFloat(document.getElementById('cac').value) || 0;
-  const grossMargin = parseFloat(document.getElementById('gross-margin').value) || 0;
-  const burnRate = parseFloat(document.getElementById('burn-rate').value) || 0;
-  const runway = parseFloat(document.getElementById('runway').value) || 0;
-  const activeCustomers = parseFloat(document.getElementById('active-customers').value) || 0;
-  const mau = parseFloat(document.getElementById('monthly-active-users').value) || 0;
-  const debtLevel = parseFloat(document.getElementById('debt-level').value) || 0;
+    const methods = Array.from(document.querySelectorAll('input[type="checkbox"]:checked')).map(input => input.value);
+    const arr = parseFloat(document.getElementById('arr').value) || 0;
+    const netProfit = parseFloat(document.getElementById('net-profit').value) || 0;
+    const growthYoy = parseFloat(document.getElementById('revenue-growth-yoy').value) || 0;
+    const customerChurn = parseFloat(document.getElementById('customer-churn').value) || 0;
+    const retentionRate = parseFloat(document.getElementById('retention-rate').value) || 0;
+    const nps = parseFloat(document.getElementById('nps').value) || 0;
+    const legalIssues = document.getElementById('legal-issues').value;
+    const ipOwnership = document.getElementById('ip-ownership').value;
+    const mrr = parseFloat(document.getElementById('mrr').value) || 0;
+    const ltv = parseFloat(document.getElementById('ltv').value) || 0;
+    const cac = parseFloat(document.getElementById('cac').value) || 0;
+    const grossMargin = parseFloat(document.getElementById('gross-margin').value) || 0;
+    const burnRate = parseFloat(document.getElementById('burn-rate').value) || 0;
+    const runway = parseFloat(document.getElementById('runway').value) || 0;
+    const activeCustomers = parseFloat(document.getElementById('active-customers').value) || 0;
+    const mau = parseFloat(document.getElementById('monthly-active-users').value) || 0;
+    const debtLevel = parseFloat(document.getElementById('debt-level').value) || 0;
 
-  let valuations = [];
-  let multiplier = 5;
-  if (growthYoy > 20) multiplier += 2;
-  if (customerChurn < 5) multiplier += 1;
-  if (retentionRate > 80) multiplier += 1;
-  if (nps > 50) multiplier += 0.5;
-  if (legalIssues !== 'none') multiplier -= 1;
-  if (ipOwnership === 'fully-owned') multiplier += 0.5;
+    let valuations = [];
+    let multiplier = 5;
+    if (growthYoy > 20) multiplier += 2;
+    if (customerChurn < 5) multiplier += 1;
+    if (retentionRate > 80) multiplier += 1;
+    if (nps > 50) multiplier += 0.5;
+    if (legalIssues !== 'none') multiplier -= 1;
+    if (ipOwnership === 'fully-owned') multiplier += 0.5;
 
-  if (methods.includes('multiplier')) {
-    const valuation = arr * multiplier;
-    valuations.push({ method: 'Revenue Multiplier', value: valuation });
+    if (methods.includes('multiplier')) {
+      const valuation = arr * multiplier;
+      valuations.push({ method: 'Revenue Multiplier', value: valuation });
+    }
+    if (methods.includes('income')) {
+      const profitMultiplier = multiplier - 1;
+      const valuation = netProfit * profitMultiplier;
+      valuations.push({ method: 'Income-Based', value: valuation });
+    }
+    if (methods.includes('earnings')) {
+      const valuation = (arr * 0.6 + netProfit * 0.4) * multiplier;
+      valuations.push({ method: 'Earnings-Based', value: valuation });
+    }
+    if (methods.includes('dcf')) {
+      const cashFlow = netProfit * 1.2;
+      const discountRate = 0.1;
+      const valuation = cashFlow / discountRate;
+      valuations.push({ method: 'DCF', value: valuation });
+    }
+
+    const avgValuation = valuations.reduce((sum, v) => sum + v.value, 0) / valuations.length;
+    const rangeLow = avgValuation * 0.9;
+    const rangeHigh = avgValuation * 1.1;
+    const confidence = Math.min(95, 60 + (methods.length * 10) + (growthYoy > 20 ? 10 : 0) + (customerChurn < 5 ? 10 : 0));
+
+    document.getElementById('valuation-amount').textContent = `$${Math.round(avgValuation).toLocaleString()}`;
+    document.getElementById('valuation-range').textContent = `$${Math.round(rangeLow).toLocaleString()} - $${Math.round(rangeHigh).toLocaleString()}`;
+    document.getElementById('confidence-score').textContent = `${Math.round(confidence)}%`;
+
+    // Charts
+    new Chart(document.getElementById('valuation-chart'), {
+      type: 'bar',
+      data: {
+        labels: valuations.map(v => v.method),
+        datasets: [{
+          label: 'Valuation ($)',
+          data: valuations.map(v => v.value),
+          backgroundColor: 'rgba(56, 178, 172, 0.6)',
+        }]
+      },
+      options: { scales: { y: { beginAtZero: true } } }
+    });
+
+    new Chart(document.getElementById('financial-chart'), {
+      type: 'bar',
+      data: {
+        labels: ['ARR', 'Net Profit', 'LTV', 'CAC'],
+        datasets: [{
+          label: 'Financial Metrics ($)',
+          data: [arr, netProfit, ltv, cac],
+          backgroundColor: ['rgba(56, 178, 172, 0.6)', 'rgba(251, 191, 36, 0.6)', 'rgba(45, 55, 72, 0.6)', 'rgba(255, 99, 132, 0.6)'],
+        }]
+      },
+      options: { scales: { y: { beginAtZero: true } } }
+    });
+
+    new Chart(document.getElementById('growth-churn-chart'), {
+      type: 'bar',
+      data: {
+        labels: ['YoY Growth', 'MoM Growth', 'Customer Churn', 'Revenue Churn'],
+        datasets: [{
+          label: 'Percentage (%)',
+          data: [
+            growthYoy,
+            parseFloat(document.getElementById('revenue-growth-mom').value) || 0,
+            customerChurn,
+            parseFloat(document.getElementById('revenue-churn').value) || 0
+          ],
+          backgroundColor: ['rgba(56, 178, 172, 0.6)', 'rgba(251, 191, 36, 0.6)', 'rgba(255, 99, 132, 0.6)', 'rgba(45, 55, 72, 0.6)'],
+        }]
+      },
+      options: { scales: { y: { beginAtZero: true, max: 100 } } }
+    });
+
+    new Chart(document.getElementById('risk-chart'), {
+      type: 'radar',
+      data: {
+        labels: ['Legal Issues', 'IP Ownership', 'Data Privacy', 'Debt Level'],
+        datasets: [{
+          label: 'Risk Score (0-10)',
+          data: [
+            legalIssues === 'none' ? 2 : legalIssues === 'minor' ? 5 : 8,
+            ipOwnership === 'fully-owned' ? 2 : ipOwnership === 'partial' ? 5 : 8,
+            document.getElementById('data-privacy').value === 'full' ? 2 : document.getElementById('data-privacy').value === 'partial' ? 5 : 8,
+            debtLevel < 100000 ? 2 : 5
+          ],
+          backgroundColor: 'rgba(255, 99, 132, 0.2)',
+          borderColor: 'rgba(255, 99, 132, 1)',
+          pointBackgroundColor: 'rgba(255, 99, 132, 1)',
+        }]
+      },
+      options: { scales: { r: { min: 0, max: 10 } } }
+    });
+
+    setupPDF({
+      valuations,
+      avgValuation,
+      rangeLow,
+      rangeHigh,
+      confidence,
+      arr,
+      netProfit,
+      growthYoy,
+      customerChurn,
+      retentionRate,
+      nps,
+      legalIssues,
+      ipOwnership,
+      mrr,
+      ltv,
+      cac,
+      grossMargin,
+      burnRate,
+      runway,
+      activeCustomers,
+      mau,
+      debtLevel,
+      multiplier
+    });
+  } catch (error) {
+    console.error('Error calculating valuation:', error);
+    alert('An error occurred while calculating valuation. Please try again.');
   }
-  if (methods.includes('income')) {
-    const profitMultiplier = multiplier - 1;
-    const valuation = netProfit * profitMultiplier;
-    valuations.push({ method: 'Income-Based', value: valuation });
-  }
-  if (methods.includes('earnings')) {
-    const valuation = (arr * 0.6 + netProfit * 0.4) * multiplier;
-    valuations.push({ method: 'Earnings-Based', value: valuation });
-  }
-  if (methods.includes('dcf')) {
-    const cashFlow = netProfit * 1.2;
-    const discountRate = 0.1;
-    const valuation = cashFlow / discountRate;
-    valuations.push({ method: 'DCF', value: valuation });
-  }
-
-  const avgValuation = valuations.reduce((sum, v) => sum + v.value, 0) / valuations.length;
-  const rangeLow = avgValuation * 0.9;
-  const rangeHigh = avgValuation * 1.1;
-  const confidence = Math.min(95, 60 + (methods.length * 10) + (growthYoy > 20 ? 10 : 0) + (customerChurn < 5 ? 10 : 0));
-
-  document.getElementById('valuation-amount').textContent = `$${Math.round(avgValuation).toLocaleString()}`;
-  document.getElementById('valuation-range').textContent = `$${Math.round(rangeLow).toLocaleString()} - $${Math.round(rangeHigh).toLocaleString()}`;
-  document.getElementById('confidence-score').textContent = `${Math.round(confidence)}%`;
-
-  // Charts
-  new Chart(document.getElementById('valuation-chart'), {
-    type: 'bar',
-    data: {
-      labels: valuations.map(v => v.method),
-      datasets: [{
-        label: 'Valuation ($)',
-        data: valuations.map(v => v.value),
-        backgroundColor: 'rgba(56, 178, 172, 0.6)',
-      }]
-    },
-    options: { scales: { y: { beginAtZero: true } } }
-  });
-
-  new Chart(document.getElementById('financial-chart'), {
-    type: 'bar',
-    data: {
-      labels: ['ARR', 'Net Profit', 'LTV', 'CAC'],
-      datasets: [{
-        label: 'Financial Metrics ($)',
-        data: [arr, netProfit, ltv, cac],
-        backgroundColor: ['rgba(56, 178, 172, 0.6)', 'rgba(251, 191, 36, 0.6)', 'rgba(45, 55, 72, 0.6)', 'rgba(255, 99, 132, 0.6)'],
-      }]
-    },
-    options: { scales: { y: { beginAtZero: true } } }
-  });
-
-  new Chart(document.getElementById('growth-churn-chart'), {
-    type: 'bar',
-    data: {
-      labels: ['YoY Growth', 'MoM Growth', 'Customer Churn', 'Revenue Churn'],
-      datasets: [{
-        label: 'Percentage (%)',
-        data: [
-          growthYoy,
-          parseFloat(document.getElementById('revenue-growth-mom').value) || 0,
-          customerChurn,
-          parseFloat(document.getElementById('revenue-churn').value) || 0
-        ],
-        backgroundColor: ['rgba(56, 178, 172, 0.6)', 'rgba(251, 191, 36, 0.6)', 'rgba(255, 99, 132, 0.6)', 'rgba(45, 55, 72, 0.6)'],
-      }]
-    },
-    options: { scales: { y: { beginAtZero: true, max: 100 } } }
-  });
-
-  new Chart(document.getElementById('risk-chart'), {
-    type: 'radar',
-    data: {
-      labels: ['Legal Issues', 'IP Ownership', 'Data Privacy', 'Debt Level'],
-      datasets: [{
-        label: 'Risk Score (0-10)',
-        data: [
-          legalIssues === 'none' ? 2 : legalIssues === 'minor' ? 5 : 8,
-          ipOwnership === 'fully-owned' ? 2 : ipOwnership === 'partial' ? 5 : 8,
-          document.getElementById('data-privacy').value === 'full' ? 2 : document.getElementById('data-privacy').value === 'partial' ? 5 : 8,
-          debtLevel < 100000 ? 2 : 5
-        ],
-        backgroundColor: 'rgba(255, 99, 132, 0.2)',
-        borderColor: 'rgba(255, 99, 132, 1)',
-        pointBackgroundColor: 'rgba(255, 99, 132, 1)',
-      }]
-    },
-    options: { scales: { r: { min: 0, max: 10 } } }
-  });
-
-  setupPDF({
-    valuations,
-    avgValuation,
-    rangeLow,
-    rangeHigh,
-    confidence,
-    arr,
-    netProfit,
-    growthYoy,
-    customerChurn,
-    retentionRate,
-    nps,
-    legalIssues,
-    ipOwnership,
-    mrr,
-    ltv,
-    cac,
-    grossMargin,
-    burnRate,
-    runway,
-    activeCustomers,
-    mau,
-    debtLevel,
-    multiplier
-  });
 }


### PR DESCRIPTION
## Summary
- wrap valuation calculation logic in try/catch with user-friendly error message
- sanitize data and add error handling around PDF generation

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a8df7cf888323ac28064d29a7c3c2