### PR TITLE
Add rule of 40, custom multipliers and discount rate

### DIFF
--- a/pro-valuation.html
+++ b/pro-valuation.html
@@ -360,7 +360,7 @@
               </div>
               <div>
                 <label for="net-profit" class="block font-medium text-gray-700 mb-1">Net Profit / EBITDA ($)</label>
-                <input type="number" id="net-profit" min="0" step="1000" placeholder="e.g., 200000" class="w-full p-2 border rounded focus:ring focus:ring-teal-400" required aria-required="true" aria-describedby="net-profit-error" />
+                <input type="number" id="net-profit" step="1000" placeholder="e.g., 200000" class="w-full p-2 border rounded focus:ring focus:ring-teal-400" required aria-required="true" aria-describedby="net-profit-error" />
                 <p id="net-profit-error" class="text-red-500 text-sm mt-1 hidden" role="alert">Please enter a valid number.</p>
               </div>
               <div>
@@ -372,6 +372,16 @@
                 <label for="runway" class="block font-medium text-gray-700 mb-1">Runway (Months)</label>
                 <input type="number" id="runway" min="0" step="1" placeholder="e.g., 12" class="w-full p-2 border rounded focus:ring focus:ring-teal-400" required aria-required="true" aria-describedby="runway-error" />
                 <p id="runway-error" class="text-red-500 text-sm mt-1 hidden" role="alert">Please enter a valid number.</p>
+              </div>
+              <div>
+                <label for="custom-multiplier" class="block font-medium text-gray-700 mb-1">Custom Revenue Multiplier (optional)</label>
+                <input type="number" id="custom-multiplier" min="0" step="0.1" placeholder="e.g., 5" class="w-full p-2 border rounded focus:ring focus:ring-teal-400" aria-describedby="custom-multiplier-error" />
+                <p id="custom-multiplier-error" class="text-red-500 text-sm mt-1 hidden" role="alert">Please enter a valid number.</p>
+              </div>
+              <div>
+                <label for="discount-rate" class="block font-medium text-gray-700 mb-1">Discount Rate (%)</label>
+                <input type="number" id="discount-rate" min="0" max="100" step="0.1" placeholder="e.g., 10" class="w-full p-2 border rounded focus:ring focus:ring-teal-400" aria-describedby="discount-rate-error" />
+                <p id="discount-rate-error" class="text-red-500 text-sm mt-1 hidden" role="alert">Please enter a value between 0 and 100.</p>
               </div>
               <p id="financial-error" class="text-red-500 text-sm mt-2 hidden" role="alert">Please fill all financial fields correctly.</p>
               <div class="mt-4 flex justify-between">
@@ -1014,6 +1024,7 @@
 
             <!-- Valuation Display -->
             <div id="valuation-results" class="text-center mb-6">
+              <div id="valuation-warnings" class="text-red-500 text-sm hidden mb-2"></div>
               <p class="text-2xl font-bold text-teal-600" id="valuation-amount">$0</p>
               <p class="text-gray-600 text-sm mt-2">Estimated Valuation Range: <span id="valuation-range">$0 - $0</span></p>
               <p class="text-gray-600 text-sm">Confidence Score: <span id="confidence-score">0%</span></p>

--- a/scripts/pdf.js
+++ b/scripts/pdf.js
@@ -32,7 +32,9 @@ export function setupPDF(data) {
         activeCustomers: sanitizeNumber(data.activeCustomers),
         mau: sanitizeNumber(data.mau),
         debtLevel: sanitizeNumber(data.debtLevel),
-        multiplier: sanitizeNumber(data.multiplier)
+        multiplier: sanitizeNumber(data.multiplier),
+        discountRate: sanitizeNumber(data.discountRate),
+        ruleOf40: sanitizeNumber(data.ruleOf40)
       };
 
       const doc = new jsPDF();
@@ -116,7 +118,7 @@ export function setupPDF(data) {
           yPos += 5;
           doc.text('Means: Balances growth and profit for investors.', margin + 5, yPos);
         } else if (v.method === 'DCF') {
-          doc.text(`Why: Discounts cash flow ($${Math.round(sanitizedData.netProfit * 1.2).toLocaleString()}) at 10%, factoring risks.`, margin + 5, yPos);
+          doc.text(`Why: Discounts cash flow ($${Math.round(sanitizedData.netProfit * 1.2).toLocaleString()}) at ${(sanitizedData.discountRate * 100).toFixed(2)}%, factoring risks.`, margin + 5, yPos);
           yPos += 5;
           doc.text(`Improve: Extend runway (${sanitizedData.runway} months) or reduce risks (e.g., legal: ${sanitizedData.legalIssues}).`, margin +5, yPos);
           yPos += 5;

--- a/scripts/validation.js
+++ b/scripts/validation.js
@@ -18,12 +18,20 @@ export function validateStep1() {
 }
 
 export function validateStep2() {
-  const inputs = ['arr', 'mrr', 'ltv', 'cac', 'gross-margin', 'net-profit', 'burn-rate', 'runway'];
+  const inputs = ['arr', 'mrr', 'ltv', 'cac', 'gross-margin', 'net-profit', 'burn-rate', 'runway', 'custom-multiplier', 'discount-rate'];
+  const optional = ['custom-multiplier', 'discount-rate'];
   let valid = true;
   inputs.forEach(id => {
     const input = document.getElementById(id);
+    if (!input) return;
     const error = document.getElementById(`${id}-error`);
-    const fieldValid = !!input.value && !(input.value < 0) && !(id === 'gross-margin' && input.value > 100);
+    const value = input.value;
+    let fieldValid;
+    if (optional.includes(id)) {
+      fieldValid = value === '' || (!(value < 0) && !(id === 'discount-rate' && value > 100));
+    } else {
+      fieldValid = !!value && !((value < 0 && id !== 'net-profit') || (id === 'gross-margin' && value > 100));
+    }
     error.classList.toggle('hidden', fieldValid);
     setFieldState(input, fieldValid);
     if (!fieldValid) valid = false;
@@ -141,7 +149,7 @@ export function setupValidationListeners() {
     cb.addEventListener('change', validateStep1);
   });
 
-  ['arr', 'mrr', 'ltv', 'cac', 'gross-margin', 'net-profit', 'burn-rate', 'runway']
+  ['arr', 'mrr', 'ltv', 'cac', 'gross-margin', 'net-profit', 'burn-rate', 'runway', 'custom-multiplier', 'discount-rate']
     .forEach(id => {
       const el = document.getElementById(id);
       if (el) el.addEventListener('input', validateStep2);


### PR DESCRIPTION
## Summary
- compute Rule of 40 to tune valuation multipliers and warn on invalid data
- add optional form inputs for custom revenue multipliers and DCF discount rate
- expose discount rate in PDF report

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a91075dd883238d9778f846e89c21