### PR TITLE
Fix valuation and PDF generation

### DIFF
--- a/scripts/pdf.js
+++ b/scripts/pdf.js
@@ -5,9 +5,9 @@ export function setupPDF(data) {
   button.onclick = async () => {
     try {
       const { jsPDF } = window.jspdf;
-      await import('https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.31/dist/jspdf.plugin.autotable.min.js');
-      const domPurifyModule = await import('https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js');
-      const DOMPurify = domPurifyModule.default;
+      await import('https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.31/dist/jspdf.plugin.autotable.js?module');
+      const domPurifyModule = await import('https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.es.min.js');
+      const DOMPurify = domPurifyModule.default || domPurifyModule;
       const sanitizeText = (str) => DOMPurify.sanitize(String(str));
       const sanitizeNumber = (num) => parseFloat(num) || 0;
       const sanitizedData = {
@@ -156,15 +156,20 @@ export function setupPDF(data) {
         { label: 'NPS', value: sanitizedData.nps, insight: sanitizedData.nps > 50 ? 'Satisfied customers.' : 'Enhance customer experience.' },
         { label: 'Debt Level', value: `$${sanitizedData.debtLevel.toLocaleString()}`, insight: sanitizedData.debtLevel < 100000 ? 'Low financial risk.' : 'Reduce debt.' }
       ];
-      doc.autoTable({
-        head: [['Label', 'Value', 'Insight']],
-        body: metrics.map(m => [m.label, m.value, m.insight]),
-        startY: yPos,
-        theme: 'striped',
-        styles: { fillColor: [240, 240, 240], textColor: [0, 0, 0] },
-        headStyles: { fillColor: [56, 178, 172] }
-      });
-      yPos = doc.lastAutoTable.finalY + 10;
+      if (typeof doc.autoTable === 'function') {
+        doc.autoTable({
+          head: [['Label', 'Value', 'Insight']],
+          body: metrics.map(m => [m.label, m.value, m.insight]),
+          startY: yPos,
+          theme: 'striped',
+          styles: { fillColor: [240, 240, 240], textColor: [0, 0, 0] },
+          headStyles: { fillColor: [56, 178, 172] }
+        });
+        yPos = doc.lastAutoTable.finalY + 10;
+      } else {
+        console.warn('autoTable plugin not loaded');
+        yPos += 10;
+      }
 
       // Graphs Pages
       const graphs = [

--- a/scripts/valuation.js
+++ b/scripts/valuation.js
@@ -3,8 +3,10 @@ import { setupPDF as setupPDFDefault } from './pdf.js';
 export async function calculateValuation(deps = {}) {
   try {
     const Chart = deps.Chart || (await import('https://cdn.jsdelivr.net/npm/chart.js')).default;
-    const jspdf = deps.jspdf || (await import('https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js'));
-    window.jspdf = jspdf;
+    const { jsPDF } =
+      deps.jspdf ||
+      (await import('https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.es.min.js'));
+    window.jspdf = { jsPDF };
 
     const methods = Array.from(document.querySelectorAll('input[type="checkbox"]:checked')).map(input => input.value);
     const arr = parseFloat(document.getElementById('arr').value) || 0;


### PR DESCRIPTION
## Summary
- use ES module versions of jspdf and autotable for PDF generation
- guard PDF table creation when autotable plugin is unavailable

## Testing
- `npm test`
- `npm run e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_689ad8652ba483239c67074dbd971b43