### PR TITLE
Make progress bar account for results step dynamically

### DIFF
--- a/pro-valuation.html
+++ b/pro-valuation.html
@@ -252,10 +252,10 @@
         <div class="mb-6">
           <div class="relative pt-1">
             <div class="overflow-hidden h-1.5 mb-2 text-xs flex rounded bg-gray-200">
-              <div id="progress-fill" class="shadow-none flex flex-col text-center whitespace-nowrap text-white justify-center bg-teal-500" role="progressbar" aria-valuemin="1" aria-valuemax="7" aria-valuenow="1"></div>
+              <div id="progress-fill" class="shadow-none flex flex-col text-center whitespace-nowrap text-white justify-center bg-teal-500" role="progressbar" aria-valuemin="1" aria-valuemax="8" aria-valuenow="1"></div>
             </div>
             <p class="text-center text-gray-600 text-sm">
-              Step <span id="current-step">1</span> of 7
+              Step <span id="current-step">1</span> of <span id="total-steps">8</span>
             </p>
           </div>
         </div>

--- a/scripts/navigation.js
+++ b/scripts/navigation.js
@@ -2,7 +2,9 @@ export function initNavigation(validation, calculateValuation) {
   const steps = document.querySelectorAll('.step');
   const progressFill = document.getElementById('progress-fill');
   const currentStepDisplay = document.getElementById('current-step');
-  const totalSteps = 7;
+  const totalStepsDisplay = document.getElementById('total-steps');
+  const totalSteps = steps.length;
+  if (totalStepsDisplay) totalStepsDisplay.textContent = totalSteps;
   let currentStep = 1;
 
   function updateProgress() {
@@ -56,7 +58,7 @@ export function initNavigation(validation, calculateValuation) {
     });
   });
 
-  for (let i = 1; i <= 7; i++) {
+  for (let i = 1; i < totalSteps; i++) {
     const nextBtn = document.getElementById(`next-btn-${i}`);
     const prevBtn = document.getElementById(`prev-btn-${i}`);
     if (nextBtn) {
@@ -64,7 +66,7 @@ export function initNavigation(validation, calculateValuation) {
         const validate = validation[`validateStep${i}`];
         if (!validate || validate()) {
           showStep(i + 1);
-          if (i === 7) calculateValuation();
+          if (i === totalSteps - 1) calculateValuation();
         }
       });
     }


### PR DESCRIPTION
## Summary
- derive total step count from DOM to include results step
- display total steps and update progress bar attributes accordingly

## Testing
- `npm test`
- `npm run e2e` *(fails: page.waitForEvent: Test timeout of 30000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_689ae25f617083238b13a5f82fbce54e