### PR TITLE
Handle zero and negative discount rates

### DIFF
--- a/scripts/valuation.js
+++ b/scripts/valuation.js
@@ -39,16 +39,19 @@ export async function calculateValuation(deps = {}) {
     const activeCustomers = parseFloat(document.getElementById('active-customers').value) || 0;
     const mau = parseFloat(document.getElementById('monthly-active-users').value) || 0;
     const debtLevel = parseFloat(document.getElementById('debt-level').value) || 0;
-    const customMultiplier = parseFloat(document.getElementById('custom-multiplier').value) || null;
-    const discountRateInput = parseFloat(document.getElementById('discount-rate').value) || null;
-    const discountRate = discountRateInput ? discountRateInput / 100 : 0.1;
+    const customMultiplier = parseFloat(document.getElementById('custom-multiplier').value);
+    const discountRateInput = parseFloat(document.getElementById('discount-rate').value);
+    const discountRate = !isNaN(discountRateInput) ? discountRateInput / 100 : 0.1;
 
     const netProfitMargin = arr > 0 ? (netProfit / arr) * 100 : 0;
     const ruleOf40 = growthYoy + netProfitMargin;
 
     let valuations = [];
     let warnings = [];
-    let multiplier = customMultiplier || 5;
+    let multiplier = !isNaN(customMultiplier) ? customMultiplier : 5;
+    if (!isNaN(discountRateInput) && discountRateInput < 0) {
+      warnings.push('Discount rate cannot be negative.');
+    }
     if (growthYoy > 20) multiplier += 2;
     if (customerChurn < 5) multiplier += 1;
     if (retentionRate > 80) multiplier += 1;

--- a/tests/calculateValuation.test.js
+++ b/tests/calculateValuation.test.js
@@ -51,4 +51,21 @@ describe('calculateValuation', () => {
     expect(document.getElementById('confidence-score').textContent).toBe('90%');
     expect(setupPDF).toHaveBeenCalled();
   });
+
+  test('warns when discount rate is zero', async () => {
+    const dcfCheckbox = document.createElement('input');
+    dcfCheckbox.type = 'checkbox';
+    dcfCheckbox.value = 'dcf';
+    dcfCheckbox.checked = true;
+    document.body.appendChild(dcfCheckbox);
+    document.getElementById('discount-rate').value = '0';
+    await calculateValuation({ Chart: ChartMock, jspdf: {}, setupPDF });
+    expect(document.getElementById('valuation-warnings').innerHTML).toContain('Discount rate must be greater than 0 for DCF method.');
+  });
+
+  test('shows message for negative discount rate', async () => {
+    document.getElementById('discount-rate').value = '-5';
+    await calculateValuation({ Chart: ChartMock, jspdf: {}, setupPDF });
+    expect(document.getElementById('valuation-warnings').innerHTML).toContain('Discount rate cannot be negative.');
+  });
 });


### PR DESCRIPTION
## Summary
- Allow a discount rate of 0 by using `isNaN` checks instead of truthy logic
- Warn users when a negative discount rate is entered
- Add unit tests for zero and negative discount rates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ae5f1c39c8323b07e69a307c3034e