### PR TITLE
Use local Chart.js for offline charts

### DIFF
--- a/scripts/valuation.js
+++ b/scripts/valuation.js
@@ -6,7 +6,7 @@ export async function calculateValuation(deps = {}) {
     if (deps.Chart) {
       Chart = deps.Chart;
     } else {
-      const chartModule = await import('https://cdn.jsdelivr.net/npm/chart.js');
+      const chartModule = await import('./vendor/chart.js');
       Chart = chartModule.default || chartModule.Chart || window.Chart;
     }
     if (!Chart) throw new Error('Chart.js not available');


### PR DESCRIPTION
## Summary
- load Chart.js from bundled vendor script instead of CDN to work offline and avoid network/CORS issues

## Testing
- `npm test`
- `npm run e2e` *(fails: Test timeout of 30000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_689bc637439c83238fc2c2dc7baf8f81