### PR TITLE
Add jsPDF CDN fallback and global check

### DIFF
--- a/pro-valuation.html
+++ b/pro-valuation.html
@@ -1292,6 +1292,7 @@
       </div>
     </div>
   </footer>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
   <script type="module" src="scripts/main.js" defer></script>
 </body>
 </html>

--- a/scripts/valuation.js
+++ b/scripts/valuation.js
@@ -4,10 +4,17 @@ export async function calculateValuation(deps = {}) {
   let jsPDF;
   let pdfEnabled = true;
   try {
-    const jspdfModule = deps.jspdf || (await import('./vendor/jspdf.es.min.js'));
+    let jspdfModule;
+    if (deps.jspdf) {
+      jspdfModule = deps.jspdf;
+    } else if (window.jspdf && (window.jspdf.jsPDF || window.jspdf.default)) {
+      jspdfModule = window.jspdf;
+    } else {
+      jspdfModule = await import('./vendor/jspdf.es.min.js');
+    }
     jsPDF = jspdfModule.jsPDF || jspdfModule.default;
     if (!jsPDF) throw new Error('jsPDF not available');
-    window.jspdf = { jsPDF };
+    if (!window.jspdf) window.jspdf = { jsPDF };
   } catch (error) {
     console.error('Failed to load jsPDF:', error);
     alert('Unable to load PDF library. PDF download disabled.');

--- a/tests/calculateValuation.test.js
+++ b/tests/calculateValuation.test.js
@@ -84,4 +84,12 @@ describe('calculateValuation', () => {
     expect(document.getElementById('download-report').disabled).toBe(true);
     expect(setupPDF).not.toHaveBeenCalled();
   });
+
+  test('uses existing window.jspdf if available', async () => {
+    const globalJspdf = { jsPDF: jest.fn() };
+    window.jspdf = globalJspdf;
+    await calculateValuation({ Chart: ChartMock, setupPDF });
+    expect(window.jspdf).toBe(globalJspdf);
+    expect(setupPDF).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- load jsPDF from CDN as a fallback before main script in pro valuation page
- avoid dynamic jsPDF import when a global instance is already present
- add test to confirm jsPDF global is reused

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c0ce446f88323b36b070b854be4fa