### PR TITLE
Fix chart rendering and expand PDF report

### DIFF
--- a/scripts/pdf.js
+++ b/scripts/pdf.js
@@ -36,6 +36,8 @@ export function setupPDF(data) {
         arr: sanitizeNumber(data.arr),
         netProfit: sanitizeNumber(data.netProfit),
         growthYoy: sanitizeNumber(data.growthYoy),
+        revenueGrowthMom: sanitizeNumber(data.revenueGrowthMom),
+        revenueChurn: sanitizeNumber(data.revenueChurn),
         customerChurn: sanitizeNumber(data.customerChurn),
         retentionRate: sanitizeNumber(data.retentionRate),
         nps: sanitizeNumber(data.nps),
@@ -149,6 +151,52 @@ export function setupPDF(data) {
         }
         yPos += 10;
       });
+
+      // Input Summary Page
+      doc.addPage();
+      addHeader();
+      yPos = 25;
+      doc.setFontSize(16);
+      doc.text('Input Summary', margin, yPos);
+      yPos += 10;
+      const inputs = [
+        ['ARR', `$${sanitizedData.arr.toLocaleString()}`],
+        ['MRR', `$${sanitizedData.mrr.toLocaleString()}`],
+        ['Net Profit', `$${sanitizedData.netProfit.toLocaleString()}`],
+        ['YoY Growth', `${sanitizedData.growthYoy}%`],
+        ['MoM Growth', `${sanitizedData.revenueGrowthMom}%`],
+        ['Customer Churn', `${sanitizedData.customerChurn}%`],
+        ['Revenue Churn', `${sanitizedData.revenueChurn}%`],
+        ['Retention Rate', `${sanitizedData.retentionRate}%`],
+        ['NPS', sanitizedData.nps],
+        ['Gross Margin', `${sanitizedData.grossMargin}%`],
+        ['CAC', `$${sanitizedData.cac.toLocaleString()}`],
+        ['LTV', `$${sanitizedData.ltv.toLocaleString()}`],
+        ['Burn Rate', `$${sanitizedData.burnRate.toLocaleString()}`],
+        ['Runway', `${sanitizedData.runway} months`],
+        ['Active Customers', sanitizedData.activeCustomers],
+        ['MAU', sanitizedData.mau],
+        ['Debt Level', `$${sanitizedData.debtLevel.toLocaleString()}`],
+        ['Legal Issues', sanitizedData.legalIssues],
+        ['IP Ownership', sanitizedData.ipOwnership],
+        ['Multiplier', sanitizedData.multiplier],
+        ['Discount Rate', `${(sanitizedData.discountRate * 100).toFixed(2)}%`],
+        ['Rule of 40', sanitizedData.ruleOf40]
+      ];
+      if (typeof doc.autoTable === 'function') {
+        doc.autoTable({
+          head: [['Metric', 'Value']],
+          body: inputs,
+          startY: yPos,
+          theme: 'striped',
+          styles: { fillColor: [240, 240, 240], textColor: [0, 0, 0] },
+          headStyles: { fillColor: [56, 178, 172] }
+        });
+        yPos = doc.lastAutoTable.finalY + 10;
+      } else {
+        console.warn('autoTable plugin not loaded');
+        yPos += 10;
+      }
 
       // Metrics Overview Page
       doc.addPage();

--- a/scripts/valuation.js
+++ b/scripts/valuation.js
@@ -123,13 +123,19 @@ export async function calculateValuation(deps = {}) {
     // Charts
     try {
       let Chart;
+      let registerables;
       if (deps.Chart) {
-        Chart = deps.Chart.default || deps.Chart;
+        Chart = deps.Chart.default || deps.Chart.Chart || deps.Chart;
+        registerables = deps.Chart.registerables;
       } else {
         const chartModule = await import('./vendor/chart.js');
         Chart = chartModule.default || chartModule.Chart || window.Chart;
+        registerables = chartModule.registerables;
       }
       if (typeof Chart !== 'function') throw new Error('Chart.js not available');
+      if (registerables && typeof Chart.register === 'function') {
+        Chart.register(...registerables);
+      }
 
       const valuationCanvas = document.getElementById('valuation-chart');
       valuationCanvas.width = 800;
@@ -221,6 +227,8 @@ export async function calculateValuation(deps = {}) {
         arr,
         netProfit,
         growthYoy,
+        revenueGrowthMom,
+        revenueChurn,
         customerChurn,
         retentionRate,
         nps,


### PR DESCRIPTION
## Summary
- Register Chart.js components so valuation, financial, growth, and risk charts render both on the page and in the PDF
- Pass monthly growth and revenue churn metrics to PDF generation and add an input summary table listing all key stats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c1f3bdc848323b07a1b259daa2111