### PR TITLE
test: mock Chart with named export

### DIFF
--- a/tests/calculateValuation.test.js
+++ b/tests/calculateValuation.test.js
@@ -10,7 +10,7 @@ class ChartMock {
 const setupPDF = jest.fn();
 
 jest.unstable_mockModule('../scripts/vendor/chart.js', () => ({
-  default: ChartMock,
+  Chart: ChartMock,
   registerables: []
 }));
 


### PR DESCRIPTION
## Summary
- fix Chart mock to export `Chart` instead of default in calculateValuation tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d9ace2ce88323bb6398456349cd46