### PR TITLE
Add detailed financial inputs and enrich Pro PDF

### DIFF
--- a/pro-valuation.html
+++ b/pro-valuation.html
@@ -430,6 +430,26 @@
                 <p id="runway-error" class="text-red-500 text-sm mt-1 hidden" role="alert">Please enter a valid number.</p>
               </div>
               <div>
+                <label for="owner-salary" class="block font-medium text-gray-700 mb-1">Owner’s Salary ($/year)</label>
+                <input type="number" id="owner-salary" min="0" step="1000" placeholder="e.g., 120000" class="w-full p-2 border rounded focus:ring focus:ring-teal-400" required aria-required="true" aria-describedby="owner-salary-error" />
+                <p id="owner-salary-error" class="text-red-500 text-sm mt-1 hidden" role="alert">Please enter a valid number.</p>
+              </div>
+              <div>
+                <label for="average-salary" class="block font-medium text-gray-700 mb-1">Average Employee Salary ($/year)</label>
+                <input type="number" id="average-salary" min="0" step="1000" placeholder="e.g., 80000" class="w-full p-2 border rounded focus:ring focus:ring-teal-400" required aria-required="true" aria-describedby="average-salary-error" />
+                <p id="average-salary-error" class="text-red-500 text-sm mt-1 hidden" role="alert">Please enter a valid number.</p>
+              </div>
+              <div>
+                <label for="employee-benefits" class="block font-medium text-gray-700 mb-1">Employee Benefits ($/year)</label>
+                <input type="number" id="employee-benefits" min="0" step="1000" placeholder="e.g., 10000" class="w-full p-2 border rounded focus:ring focus:ring-teal-400" required aria-required="true" aria-describedby="employee-benefits-error" />
+                <p id="employee-benefits-error" class="text-red-500 text-sm mt-1 hidden" role="alert">Please enter a valid number.</p>
+              </div>
+              <div>
+                <label for="years-operating" class="block font-medium text-gray-700 mb-1">Years in Operation</label>
+                <input type="number" id="years-operating" min="0" step="1" placeholder="e.g., 3" class="w-full p-2 border rounded focus:ring focus:ring-teal-400" required aria-required="true" aria-describedby="years-operating-error" />
+                <p id="years-operating-error" class="text-red-500 text-sm mt-1 hidden" role="alert">Please enter a valid number.</p>
+              </div>
+              <div>
                 <label for="business-type" class="block font-medium text-gray-700 mb-1">Business Type</label>
                 <select id="business-type" class="w-full p-2 border rounded focus:ring focus:ring-teal-400" required aria-required="true" aria-describedby="business-type-error">
                   <option value="" disabled selected>Select type</option>

--- a/scripts/pdf.js
+++ b/scripts/pdf.js
@@ -50,6 +50,10 @@ export function setupPDF(data) {
         grossMargin: sanitizeNumber(data.grossMargin),
         burnRate: sanitizeNumber(data.burnRate),
         runway: sanitizeNumber(data.runway),
+        ownerSalary: sanitizeNumber(data.ownerSalary),
+        averageSalary: sanitizeNumber(data.averageSalary),
+        employeeBenefits: sanitizeNumber(data.employeeBenefits),
+        yearsOperating: sanitizeNumber(data.yearsOperating),
         businessType: sanitizeText(data.businessType),
         baseMultiplier: sanitizeNumber(data.baseMultiplier),
         activeCustomers: sanitizeNumber(data.activeCustomers),
@@ -202,6 +206,10 @@ export function setupPDF(data) {
         ['LTV', `$${sanitizedData.ltv.toLocaleString()}`],
         ['Burn Rate', `$${sanitizedData.burnRate.toLocaleString()}`],
         ['Runway', `${sanitizedData.runway} months`],
+        ['Owner Salary', `$${sanitizedData.ownerSalary.toLocaleString()}`],
+        ['Average Employee Salary', `$${sanitizedData.averageSalary.toLocaleString()}`],
+        ['Employee Benefits', `$${sanitizedData.employeeBenefits.toLocaleString()}`],
+        ['Years in Operation', sanitizedData.yearsOperating],
         ['Active Customers', sanitizedData.activeCustomers],
         ['MAU', sanitizedData.mau],
         ['Customer Segment', sanitizedData.customerSegment],
@@ -302,6 +310,30 @@ export function setupPDF(data) {
           value: `${sanitizedData.runway} months`,
           importance: 'Estimates months before cash runs out.',
           insight: sanitizedData.runway > 12 ? 'Long-term stability.' : 'Secure funding.'
+        },
+        {
+          label: 'Owner Salary',
+          value: `$${sanitizedData.ownerSalary.toLocaleString()}`,
+          importance: 'Shows owner compensation excluded from profit.',
+          insight: sanitizedData.ownerSalary > 0 ? 'Track SDE adjustments.' : 'Enter salary for clarity.'
+        },
+        {
+          label: 'Average Employee Salary',
+          value: `$${sanitizedData.averageSalary.toLocaleString()}`,
+          importance: 'Highlights staff cost structure.',
+          insight: sanitizedData.averageSalary > 0 ? 'Competitive pay scale.' : 'Benchmark salaries.'
+        },
+        {
+          label: 'Employee Benefits',
+          value: `$${sanitizedData.employeeBenefits.toLocaleString()}`,
+          importance: 'Captures non-salary compensation.',
+          insight: sanitizedData.employeeBenefits > 0 ? 'Include in cost planning.' : 'Track benefit spend.'
+        },
+        {
+          label: 'Years in Operation',
+          value: sanitizedData.yearsOperating,
+          importance: 'Indicates business maturity.',
+          insight: sanitizedData.yearsOperating >= 2 ? 'Established track record.' : 'Early-stage risk.'
         },
         {
           label: 'YoY Growth',

--- a/scripts/validation.js
+++ b/scripts/validation.js
@@ -18,7 +18,7 @@ export function validateStep1() {
 }
 
 export function validateStep2() {
-  const inputs = ['arr', 'mrr', 'ltv', 'cac', 'gross-margin', 'net-profit', 'burn-rate', 'runway', 'custom-multiplier', 'discount-rate'];
+  const inputs = ['arr', 'mrr', 'ltv', 'cac', 'gross-margin', 'net-profit', 'burn-rate', 'runway', 'owner-salary', 'average-salary', 'employee-benefits', 'years-operating', 'custom-multiplier', 'discount-rate'];
   const optional = ['custom-multiplier', 'discount-rate'];
   let valid = true;
   inputs.forEach(id => {
@@ -204,7 +204,7 @@ export function setupValidationListeners() {
     cb.addEventListener('change', validateStep1);
   });
 
-  ['arr', 'mrr', 'ltv', 'cac', 'gross-margin', 'net-profit', 'burn-rate', 'runway', 'custom-multiplier', 'discount-rate']
+  ['arr', 'mrr', 'ltv', 'cac', 'gross-margin', 'net-profit', 'burn-rate', 'runway', 'owner-salary', 'average-salary', 'employee-benefits', 'years-operating', 'custom-multiplier', 'discount-rate']
     .forEach(id => {
       const el = document.getElementById(id);
       if (el) el.addEventListener('input', validateStep2);

--- a/scripts/valuation.js
+++ b/scripts/valuation.js
@@ -43,6 +43,10 @@ export async function calculateValuation(deps = {}) {
     const grossMargin = parseFloat(document.getElementById('gross-margin').value) || 0;
     const burnRate = parseFloat(document.getElementById('burn-rate').value) || 0;
     const runway = parseFloat(document.getElementById('runway').value) || 0;
+    const ownerSalary = parseFloat(document.getElementById('owner-salary')?.value) || 0;
+    const averageSalary = parseFloat(document.getElementById('average-salary')?.value) || 0;
+    const employeeBenefits = parseFloat(document.getElementById('employee-benefits')?.value) || 0;
+    const yearsOperating = parseInt(document.getElementById('years-operating')?.value) || 0;
     const businessTypeSelect = document.getElementById('business-type');
     const baseMultiplier = businessTypeSelect ? parseFloat(businessTypeSelect.value) || 5 : 5;
     const businessType = businessTypeSelect ? businessTypeSelect.options[businessTypeSelect.selectedIndex]?.dataset.name || '' : '';
@@ -251,6 +255,10 @@ export async function calculateValuation(deps = {}) {
         grossMargin,
         burnRate,
         runway,
+        ownerSalary,
+        averageSalary,
+        employeeBenefits,
+        yearsOperating,
         businessType,
         baseMultiplier,
         activeCustomers,

--- a/tests/validation.test.js
+++ b/tests/validation.test.js
@@ -18,7 +18,7 @@ describe('validation steps', () => {
   });
 
   test('validateStep2', () => {
-    const ids = ['arr','mrr','ltv','cac','gross-margin','net-profit','burn-rate','runway','custom-multiplier','discount-rate'];
+    const ids = ['arr','mrr','ltv','cac','gross-margin','net-profit','burn-rate','runway','owner-salary','average-salary','employee-benefits','years-operating','custom-multiplier','discount-rate'];
     document.body.innerHTML = ids.map(id => `
         <input id="${id}" value="10" />
         <p id="${id}-error" class="hidden"></p>


### PR DESCRIPTION
## Summary
- add missing owner salary, staff salary, benefits, and age fields to Pro valuation form
- validate new inputs and pipe them into valuation calculation
- expand PDF report with detailed input summary and key metrics to justify valuations

## Testing
- `npm test`
- `npm run e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_689f5a3a69a883238b6f0b6aa99a8f93