### PR TITLE
Fix jsPDF autoTable plugin loading

### DIFF
--- a/scripts/pdf.js
+++ b/scripts/pdf.js
@@ -10,8 +10,8 @@ export function setupPDF(data) {
         return;
       }
       try {
-        const { default: autoTable } = await import('./vendor/jspdf.plugin.autotable.js');
-        autoTable(jsPDF);
+        const { applyPlugin } = await import('./vendor/jspdf.plugin.autotable.js');
+        applyPlugin(jsPDF);
       } catch (error) {
         console.error('Failed to load jsPDF autotable plugin:', error);
         alert('Failed to load table plugin. Please refresh and try again.');


### PR DESCRIPTION
## Summary
- properly register the jsPDF autoTable plugin before generating PDF reports

## Testing
- `npm test`
- `npm run e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_689f601b17d08323a0fe41e160bb5069