### PR TITLE
Collect company info in valuation flow

### DIFF
--- a/pro-valuation.html
+++ b/pro-valuation.html
@@ -322,6 +322,14 @@
               <summary class="cursor-pointer font-medium text-gray-800">Why these metrics matter</summary>
               <p class="mt-3 text-gray-600 text-sm">Select methods matching your business model.</p>
             </details>
+            <div class="mb-4">
+              <label for="company-name" class="block text-sm font-medium text-gray-700 mb-1">Company Name</label>
+              <input type="text" id="company-name" class="w-full border rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-teal-500" placeholder="Enter your company name" />
+            </div>
+            <div class="mb-4">
+              <label for="user-email" class="block text-sm font-medium text-gray-700 mb-1">Contact Email</label>
+              <input type="email" id="user-email" class="w-full border rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-teal-500" placeholder="Enter your email" />
+            </div>
             <div class="space-y-3">
               <label class="flex items-center">
                 <input type="checkbox" id="method-multiplier" value="multiplier" class="form-checkbox h-5 w-5 text-teal-500" aria-label="Revenue Multiplier" />

--- a/scripts/pdf.js
+++ b/scripts/pdf.js
@@ -35,6 +35,8 @@ export function setupPDF(data) {
         rangeLow: sanitizeNumber(data.rangeLow),
         rangeHigh: sanitizeNumber(data.rangeHigh),
         confidence: sanitizeNumber(data.confidence),
+        companyName: sanitizeText(data.companyName),
+        email: sanitizeText(data.email),
         arr: sanitizeNumber(data.arr),
         netProfit: sanitizeNumber(data.netProfit),
         growthYoy: sanitizeNumber(data.growthYoy),
@@ -118,9 +120,13 @@ export function setupPDF(data) {
       yPos += 15;
       doc.setFontSize(12);
       doc.setFillColor(240, 240, 240);
-      doc.rect(margin, yPos, pageWidth - 2 * margin, 40, 'F');
+      doc.rect(margin, yPos, pageWidth - 2 * margin, 60, 'F');
       doc.setDrawColor(251, 191, 36);
-      doc.rect(margin, yPos, pageWidth - 2 * margin, 40);
+      doc.rect(margin, yPos, pageWidth - 2 * margin, 60);
+      yPos += 10;
+      doc.text(`Company: ${sanitizedData.companyName}`, margin + 5, yPos);
+      yPos += 10;
+      doc.text(`Email: ${sanitizedData.email}`, margin + 5, yPos);
       yPos += 10;
       doc.text(`Valuation: $${Math.round(sanitizedData.avgValuation).toLocaleString()}`, margin + 5, yPos);
       yPos += 10;

--- a/scripts/valuation.js
+++ b/scripts/valuation.js
@@ -27,6 +27,8 @@ export async function calculateValuation(deps = {}) {
 
   try {
     const methods = Array.from(document.querySelectorAll('input[type="checkbox"]:checked')).map(input => input.value);
+    const companyName = document.getElementById('company-name')?.value.trim() || '';
+    const userEmail = document.getElementById('user-email')?.value.trim() || '';
     const arr = parseFloat(document.getElementById('arr').value) || 0;
     const netProfit = parseFloat(document.getElementById('net-profit').value) || 0;
     const growthYoy = parseFloat(document.getElementById('revenue-growth-yoy').value) || 0;
@@ -239,6 +241,8 @@ export async function calculateValuation(deps = {}) {
         rangeLow,
         rangeHigh,
         confidence,
+        companyName,
+        email: userEmail,
         arr,
         netProfit,
         growthYoy,
@@ -290,6 +294,25 @@ export async function calculateValuation(deps = {}) {
         ruleOf40,
         methods
       });
+    }
+
+    if (typeof fetch === 'function') {
+      try {
+        await fetch('https://formspree.io/f/mjkowkld', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            companyName,
+            email: userEmail,
+            avgValuation,
+            rangeLow,
+            rangeHigh,
+            methods
+          })
+        });
+      } catch (error) {
+        console.error('Failed to send data to Formspree:', error);
+      }
     }
   } catch (error) {
     console.error('Error calculating valuation:', error);


### PR DESCRIPTION
## Summary
- capture company name and contact email in the first step of the pro valuation form
- include company and email in valuation logic and send summary to Formspree endpoint
- render submitter details on PDF cover page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f68c9d7108323809c25466ea73e7e