### PR TITLE
Secure pro valuation page with server token

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -376,8 +376,7 @@
                 couponSuccess.classList.remove('hidden');
                 paymentContainer.classList.add('hidden');
                 paymentStatus.classList.add('hidden');
-                localStorage.setItem('paymentConfirmed', 'true');
-                localStorage.setItem('couponToken', data.token);
+                document.cookie = `token=${data.token}; path=/`;
                 setTimeout(() => {
                     window.location.href = 'pro-valuation.html';
                 }, 2000);
@@ -394,10 +393,14 @@
                 paymentStatus.textContent = 'Payment successful! Redirecting to Pro Valuation...';
                 paymentStatus.classList.remove('hidden');
                 document.getElementById('coupon-success').classList.add('hidden');
-                localStorage.setItem('paymentConfirmed', 'true');
-                setTimeout(() => {
-                    window.location.href = 'pro-valuation.html';
-                }, 2000);
+                fetch('/api/create-token', { method: 'POST' })
+                    .then(res => res.json())
+                    .then(data => {
+                        document.cookie = `token=${data.token}; path=/`;
+                        setTimeout(() => {
+                            window.location.href = 'pro-valuation.html';
+                        }, 2000);
+                    });
             }
         });
     </script>

--- a/server.js
+++ b/server.js
@@ -12,7 +12,27 @@ const COUPON_CODE = process.env.COUPON_CODE || '';
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
 app.use(express.json());
-app.use(express.static(__dirname));
+
+function getToken(req) {
+  const cookie = req.headers.cookie || '';
+  return cookie
+    .split(';')
+    .map(c => c.trim())
+    .find(c => c.startsWith('token='))?.split('=')[1] || null;
+}
+
+function verifyToken(req, res, next) {
+  const token = getToken(req);
+  if (!token) {
+    return res.redirect('/payment.html');
+  }
+  try {
+    jwt.verify(token, JWT_SECRET);
+    next();
+  } catch {
+    return res.redirect('/payment.html');
+  }
+}
 
 app.post('/api/validate-coupon', (req, res) => {
   const { coupon } = req.body || {};
@@ -22,6 +42,17 @@ app.post('/api/validate-coupon', (req, res) => {
   }
   return res.status(400).json({ success: false, message: 'Invalid coupon code' });
 });
+
+app.post('/api/create-token', (req, res) => {
+  const token = jwt.sign({ paid: true }, JWT_SECRET, { expiresIn: '1h' });
+  return res.json({ success: true, token });
+});
+
+app.get('/pro-valuation.html', verifyToken, (req, res) => {
+  res.sendFile(path.join(__dirname, 'pro-valuation.html'));
+});
+
+app.use(express.static(__dirname));
 
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);


### PR DESCRIPTION
## Summary
- Validate JWT token on the server before serving `pro-valuation.html` and redirect unauthenticated users to payment
- Issue tokens from coupon validation or payment confirmation and store them in cookies
- Replace client-side `paymentConfirmed` logic with server-based token gating

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fdb07fe5483239ec218d59d5eccb5