### PR TITLE
Ensure payment coupon code is freeval05

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ const __dirname = path.dirname(__filename);
 
 const app = express();
 const PORT = process.env.PORT || 3000;
-const COUPON_CODE = process.env.COUPON_CODE || '';
+const COUPON_CODE = process.env.COUPON_CODE || 'freeval05';
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
 app.use(express.json());


### PR DESCRIPTION
## Summary
- Default the `COUPON_CODE` to `freeval05` so payment page coupon validation works out of the box

## Testing
- `npm test`
- `npm run e2e` *(fails: page.check timeout waiting for #method-multiplier)*

------
https://chatgpt.com/codex/tasks/task_e_689fddd19abc8323a86a3328eea9b695