### PR TITLE
Improve method explanations placement

### DIFF
--- a/pro-valuation.html
+++ b/pro-valuation.html
@@ -318,39 +318,36 @@
             <p class="text-gray-600 mb-4 text-sm">
               Choose up to 3 valuation methods for your SaaS business.
             </p>
-            <details class="mt-4 rounded-lg bg-gray-50 p-4">
-              <summary class="cursor-pointer font-medium text-gray-800">What do these methods mean?</summary>
-              <div class="explanation-section">
-                <div class="explanation-box">
-                  <h4>Revenue Multiplier</h4>
-                  <p><strong>What:</strong> Multiplies your annual revenue (ARR) by a factor (e.g., 5-8).</p>
-                  <p><strong>Why:</strong> Ideal for stable SaaS revenue, showing investor value.</p>
-                  <p><strong>Scenario:</strong> $1M ARR with a 6x multiplier = $6M valuation.</p>
-                  <p><strong>Source:</strong> ARR from Stripe; multipliers from industry reports.</p>
-                </div>
-                <div class="explanation-box">
-                  <h4>Income-Based</h4>
-                  <p><strong>What:</strong> Multiplies net profit by a factor (e.g., 4-7).</p>
-                  <p><strong>Why:</strong> Highlights profitability for cash-generating businesses.</p>
-                  <p><strong>Scenario:</strong> $200K profit with a 5x multiplier = $1M valuation.</p>
-                  <p><strong>Source:</strong> Net profit from QuickBooks; multipliers from advisors.</p>
-                </div>
-                <div class="explanation-box">
-                  <h4>Earnings-Based</h4>
-                  <p><strong>What:</strong> Combines ARR and profit, adjusted for growth.</p>
-                  <p><strong>Why:</strong> Balances revenue and profit for growing SaaS.</p>
-                  <p><strong>Scenario:</strong> $1M ARR, $200K profit = $1.5M valuation.</p>
-                  <p><strong>Source:</strong> ARR/profit from reports; retention from CRM.</p>
-                </div>
-                <div class="explanation-box">
-                  <h4>Discounted Cash Flow (DCF)</h4>
-                  <p><strong>What:</strong> Discounts future cash flows to present value.</p>
-                  <p><strong>Why:</strong> Best for long-term growth potential.</p>
-                  <p><strong>Scenario:</strong> $1M ARR, 20% growth = $3M valuation.</p>
-                  <p><strong>Source:</strong> Projections from LivePlan; discount rates from analysts.</p>
-                </div>
+            <div id="step-1-explanations" class="hidden hidden-explanations">
+              <div class="explanation-box" data-for="method-multiplier">
+                <h4>Revenue Multiplier</h4>
+                <p><strong>What:</strong> Multiplies your annual revenue (ARR) by a factor (e.g., 5-8).</p>
+                <p><strong>Why:</strong> Ideal for stable SaaS revenue, showing investor value.</p>
+                <p><strong>Scenario:</strong> $1M ARR with a 6x multiplier = $6M valuation.</p>
+                <p><strong>Source:</strong> ARR from Stripe; multipliers from industry reports.</p>
               </div>
-            </details>
+              <div class="explanation-box" data-for="method-income">
+                <h4>Income-Based</h4>
+                <p><strong>What:</strong> Multiplies net profit by a factor (e.g., 4-7).</p>
+                <p><strong>Why:</strong> Highlights profitability for cash-generating businesses.</p>
+                <p><strong>Scenario:</strong> $200K profit with a 5x multiplier = $1M valuation.</p>
+                <p><strong>Source:</strong> Net profit from QuickBooks; multipliers from advisors.</p>
+              </div>
+              <div class="explanation-box" data-for="method-earnings">
+                <h4>Earnings-Based</h4>
+                <p><strong>What:</strong> Combines ARR and profit, adjusted for growth.</p>
+                <p><strong>Why:</strong> Balances revenue and profit for growing SaaS.</p>
+                <p><strong>Scenario:</strong> $1M ARR, $200K profit = $1.5M valuation.</p>
+                <p><strong>Source:</strong> ARR/profit from reports; retention from CRM.</p>
+              </div>
+              <div class="explanation-box" data-for="method-dcf">
+                <h4>Discounted Cash Flow (DCF)</h4>
+                <p><strong>What:</strong> Discounts future cash flows to present value.</p>
+                <p><strong>Why:</strong> Best for long-term growth potential.</p>
+                <p><strong>Scenario:</strong> $1M ARR, 20% growth = $3M valuation.</p>
+                <p><strong>Source:</strong> Projections from LivePlan; discount rates from analysts.</p>
+              </div>
+            </div>
             <div class="mb-4">
               <label for="company-name" class="block text-sm font-medium text-gray-700 mb-1">Company Name</label>
               <input type="text" id="company-name" class="w-full border rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-teal-500" placeholder="Enter your company name" />
@@ -391,60 +388,59 @@
             <p class="text-gray-600 mb-4 text-sm">
               Enter key financial figures for your business.
             </p>
-              <details class="mt-4 rounded-lg bg-gray-50 p-4">
-                <summary class="cursor-pointer font-medium text-gray-800">Why these metrics matter</summary>
+              <div id="step-2-explanations" class="hidden hidden-explanations">
                 <p class="mt-3 text-gray-600 text-sm">Use latest financial statements.</p>
                 <div class="explanation-section">
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="arr">
                     <h4>Annual Recurring Revenue (ARR)</h4>
                     <p><strong>What:</strong> Yearly subscription revenue.</p>
                     <p><strong>Why:</strong> Shows revenue stability, key for valuation.</p>
                     <p><strong>Scenario:</strong> 1,000 customers at $100/month = $1.2M ARR.</p>
                     <p><strong>Source:</strong> Billing systems (e.g., Stripe).</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="mrr">
                     <h4>Monthly Recurring Revenue (MRR)</h4>
                     <p><strong>What:</strong> Monthly subscription revenue.</p>
                     <p><strong>Why:</strong> Tracks short-term revenue trends.</p>
                     <p><strong>Scenario:</strong> 500 customers at $200/month = $100K MRR.</p>
                     <p><strong>Source:</strong> Payment processors (e.g., PayPal).</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="ltv">
                     <h4>Customer Lifetime Value (LTV)</h4>
                     <p><strong>What:</strong> Total revenue per customer over time.</p>
                     <p><strong>Why:</strong> High LTV boosts business value.</p>
                     <p><strong>Scenario:</strong> $50/month for 4 years = $2,400 LTV.</p>
                     <p><strong>Source:</strong> CRM (e.g., Salesforce).</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="cac">
                     <h4>Customer Acquisition Cost (CAC)</h4>
                     <p><strong>What:</strong> Cost to gain a new customer.</p>
                     <p><strong>Why:</strong> Low CAC improves profitability.</p>
                     <p><strong>Scenario:</strong> $10K ads for 20 customers = $500 CAC.</p>
                     <p><strong>Source:</strong> Ad platforms (e.g., Google Ads).</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="gross-margin">
                     <h4>Gross Margin</h4>
                     <p><strong>What:</strong> Revenue after direct costs (%).</p>
                     <p><strong>Why:</strong> High margins show efficiency.</p>
                     <p><strong>Scenario:</strong> $100K revenue, $25K costs = 75% margin.</p>
                     <p><strong>Source:</strong> Income statement (e.g., QuickBooks).</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="net-profit">
                     <h4>Net Profit / EBITDA</h4>
                     <p><strong>What:</strong> Revenue after all expenses.</p>
                     <p><strong>Why:</strong> High profit signals financial health.</p>
                     <p><strong>Scenario:</strong> $1M revenue, $800K expenses = $200K profit.</p>
                     <p><strong>Source:</strong> Profit/loss statement.</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="burn-rate">
                     <h4>Monthly Burn Rate</h4>
                     <p><strong>What:</strong> Monthly cash loss.</p>
                     <p><strong>Why:</strong> Low burn rate reassures investors.</p>
                     <p><strong>Scenario:</strong> $50K spend, $25K revenue = $25K burn.</p>
                     <p><strong>Source:</strong> Financial reports.</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="runway">
                     <h4>Runway</h4>
                     <p><strong>What:</strong> Months until cash runs out.</p>
                     <p><strong>Why:</strong> Longer runway boosts sustainability.</p>
@@ -452,7 +448,7 @@
                     <p><strong>Source:</strong> Cash balance ÷ burn rate.</p>
                   </div>
                 </div>
-              </details>
+              </div>
             <div class="space-y-3">
               <div>
                 <label for="arr" class="block font-medium text-gray-700 mb-1">Annual Recurring Revenue (ARR) ($)</label>
@@ -565,32 +561,31 @@
             <p class="text-gray-600 mb-4 text-sm">
               Enter revenue growth and churn metrics.
             </p>
-              <details class="mt-4 rounded-lg bg-gray-50 p-4">
-                <summary class="cursor-pointer font-medium text-gray-800">Why these metrics matter</summary>
+              <div id="step-3-explanations" class="hidden hidden-explanations">
                 <p class="mt-3 text-gray-600 text-sm">These impact valuation multipliers.</p>
                 <div class="explanation-section">
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="revenue-growth-yoy">
                     <h4>Revenue Growth (YoY)</h4>
                     <p><strong>What:</strong> Annual revenue growth percentage.</p>
                     <p><strong>Why:</strong> High growth signals expansion potential.</p>
                     <p><strong>Scenario:</strong> $1M to $1.2M revenue = 20% YoY growth.</p>
                     <p><strong>Source:</strong> Financial reports (e.g., QuickBooks).</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="revenue-growth-mom">
                     <h4>Revenue Growth (MoM)</h4>
                     <p><strong>What:</strong> Monthly revenue growth percentage.</p>
                     <p><strong>Why:</strong> Shows short-term growth trends.</p>
                     <p><strong>Scenario:</strong> $100K to $103K revenue = 3% MoM growth.</p>
                     <p><strong>Source:</strong> Billing systems (e.g., Stripe).</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="customer-churn">
                     <h4>Customer Churn Rate</h4>
                     <p><strong>What:</strong> Percentage of customers leaving monthly.</p>
                     <p><strong>Why:</strong> Low churn boosts revenue stability.</p>
                     <p><strong>Scenario:</strong> 50 of 1,000 customers leave = 5% churn.</p>
                     <p><strong>Source:</strong> CRM (e.g., Salesforce).</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="revenue-churn">
                     <h4>Revenue Churn Rate</h4>
                     <p><strong>What:</strong> Percentage of revenue lost monthly.</p>
                     <p><strong>Why:</strong> Low revenue churn supports valuation.</p>
@@ -598,7 +593,7 @@
                     <p><strong>Source:</strong> Billing tools (e.g., Chargebee).</p>
                   </div>
                 </div>
-              </details>
+              </div>
             <div class="space-y-3">
               <div>
                 <label for="revenue-growth-yoy" class="block font-medium text-gray-700 mb-1">Revenue Growth (YoY %)</label>
@@ -634,46 +629,45 @@
             <p class="text-gray-600 mb-4 text-sm">
               Provide customer and market details.
             </p>
-            <details class="mt-4 rounded-lg bg-gray-50 p-4">
-              <summary class="cursor-pointer font-medium text-gray-800">Why these metrics matter</summary>
+            <div id="step-4-explanations" class="hidden hidden-explanations">
               <p class="mt-3 text-gray-600 text-sm">These adjust valuation risk.</p>
               <div class="explanation-section">
-                <div class="explanation-box">
+                <div class="explanation-box" data-for="active-customers">
                   <h4>Active Customers</h4>
                   <p><strong>What:</strong> Number of paying customers.</p>
                   <p><strong>Why:</strong> More customers increase revenue.</p>
                   <p><strong>Scenario:</strong> 1,500 customers = strong base.</p>
                   <p><strong>Source:</strong> Subscription tools (e.g., Stripe).</p>
                 </div>
-                <div class="explanation-box">
+                <div class="explanation-box" data-for="monthly-active-users">
                   <h4>Monthly Active Users (MAU)</h4>
                   <p><strong>What:</strong> Users engaging monthly.</p>
                   <p><strong>Why:</strong> High MAU shows product popularity.</p>
                   <p><strong>Scenario:</strong> 2,000 MAU = strong engagement.</p>
                   <p><strong>Source:</strong> Analytics (e.g., Google Analytics).</p>
                 </div>
-                <div class="explanation-box">
+                <div class="explanation-box" data-for="retention-rate">
                   <h4>Retention Rate</h4>
                   <p><strong>What:</strong> Percentage of customers staying.</p>
                   <p><strong>Why:</strong> High retention boosts stability.</p>
                   <p><strong>Scenario:</strong> 85% retention = loyal customers.</p>
                   <p><strong>Source:</strong> CRM (e.g., HubSpot).</p>
                 </div>
-                <div class="explanation-box">
+                <div class="explanation-box" data-for="nps">
                   <h4>Net Promoter Score (NPS)</h4>
                   <p><strong>What:</strong> Likelihood of customer referrals (-100 to 100).</p>
                   <p><strong>Why:</strong> High NPS indicates satisfaction.</p>
                   <p><strong>Scenario:</strong> NPS 70 = happy customers.</p>
                   <p><strong>Source:</strong> Surveys (e.g., SurveyMonkey).</p>
                 </div>
-                <div class="explanation-box">
+                <div class="explanation-box" data-for="customer-segment">
                   <h4>Customer Segment</h4>
                   <p><strong>What:</strong> Main customer type (e.g., enterprise).</p>
                   <p><strong>Why:</strong> Impacts growth and risk.</p>
                   <p><strong>Scenario:</strong> Enterprise = high-value deals.</p>
                   <p><strong>Source:</strong> CRM customer data.</p>
                 </div>
-                <div class="explanation-box">
+                <div class="explanation-box" data-for="buyer-type">
                   <h4>Buyer Type / Exit Potential</h4>
                   <p><strong>What:</strong> Likely buyers (e.g., competitors).</p>
                   <p><strong>Why:</strong> Influences valuation estimates.</p>
@@ -681,7 +675,7 @@
                   <p><strong>Source:</strong> Industry research or advisors.</p>
                 </div>
               </div>
-            </details>
+            </div>
             <div class="space-y-3">
               <div>
                 <label for="active-customers" class="block font-medium text-gray-700 mb-1">Active Customers</label>
@@ -739,46 +733,45 @@
             <p class="text-gray-600 mb-4 text-sm">
               Detail your product and tech maturity.
             </p>
-            <details class="mt-4 rounded-lg bg-gray-50 p-4">
-              <summary class="cursor-pointer font-medium text-gray-800">Why these metrics matter</summary>
+            <div id="step-5-explanations" class="hidden hidden-explanations">
               <p class="mt-3 text-gray-600 text-sm">Tech strength impacts valuation.</p>
               <div class="explanation-section">
-                <div class="explanation-box">
+                <div class="explanation-box" data-for="product-market-fit">
                   <h4>Product-Market Fit</h4>
                   <p><strong>What:</strong> How well product meets customer needs.</p>
                   <p><strong>Why:</strong> Strong fit drives growth.</p>
                   <p><strong>Scenario:</strong> High usage = strong fit.</p>
                   <p><strong>Source:</strong> Feedback (e.g., Mixpanel).</p>
                 </div>
-                <div class="explanation-box">
+                <div class="explanation-box" data-for="proprietary-tech">
                   <h4>Proprietary Technology / IP</h4>
                   <p><strong>What:</strong> Unique, protected technology.</p>
                   <p><strong>Why:</strong> Hard-to-copy tech boosts value.</p>
                   <p><strong>Scenario:</strong> Patented algorithm = higher valuation.</p>
                   <p><strong>Source:</strong> Legal team or patent records.</p>
                 </div>
-                <div class="explanation-box">
+                <div class="explanation-box" data-for="code-quality">
                   <h4>Code Quality Reviewed</h4>
                   <p><strong>What:</strong> Clean, reliable code.</p>
                   <p><strong>Why:</strong> Reduces maintenance risks.</p>
                   <p><strong>Scenario:</strong> External audit = buyer confidence.</p>
                   <p><strong>Source:</strong> Tech team or auditors.</p>
                 </div>
-                <div class="explanation-box">
+                <div class="explanation-box" data-for="scalable-infrastructure">
                   <h4>Scalable Infrastructure</h4>
                   <p><strong>What:</strong> Tech that handles growth.</p>
                   <p><strong>Why:</strong> Supports expansion without issues.</p>
                   <p><strong>Scenario:</strong> 10x user capacity = scalable.</p>
                   <p><strong>Source:</strong> Cloud provider (e.g., AWS).</p>
                 </div>
-                <div class="explanation-box">
+                <div class="explanation-box" data-for="feature-release-frequency">
                   <h4>Feature Release Frequency</h4>
                   <p><strong>What:</strong> How often new features launch.</p>
                   <p><strong>Why:</strong> Shows innovation pace.</p>
                   <p><strong>Scenario:</strong> Weekly releases = active dev.</p>
                   <p><strong>Source:</strong> Dev logs (e.g., Jira).</p>
                 </div>
-                <div class="explanation-box">
+                <div class="explanation-box" data-for="security-compliance">
                   <h4>Security Compliance</h4>
                   <p><strong>What:</strong> Adherence to data security laws.</p>
                   <p><strong>Why:</strong> Reduces legal risks.</p>
@@ -786,7 +779,7 @@
                   <p><strong>Source:</strong> Legal team or audits.</p>
                 </div>
               </div>
-            </details>
+            </div>
             <div class="space-y-3">
               <div>
                 <label for="product-market-fit" class="block font-medium text-gray-700 mb-1">Product-Market Fit</label>
@@ -866,53 +859,52 @@
             <p class="text-gray-600 mb-4 text-sm">
               Share team and operational details.
             </p>
-              <details class="mt-4 rounded-lg bg-gray-50 p-4">
-                <summary class="cursor-pointer font-medium text-gray-800">Why these metrics matter</summary>
+              <div id="step-6-explanations" class="hidden hidden-explanations">
                 <p class="mt-3 text-gray-600 text-sm">Strong teams boost valuation.</p>
                 <div class="explanation-section">
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="fte">
                     <h4>Full-Time Employees</h4>
                     <p><strong>What:</strong> Number of full-time staff.</p>
                     <p><strong>Why:</strong> Shows operational capacity.</p>
                     <p><strong>Scenario:</strong> 25 employees = robust team.</p>
                     <p><strong>Source:</strong> HR records (e.g., Gusto).</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="key-staff">
                     <h4>Founders / Key Staff</h4>
                     <p><strong>What:</strong> Critical leadership count.</p>
                     <p><strong>Why:</strong> Strong leaders boost confidence.</p>
                     <p><strong>Scenario:</strong> 3 founders = committed team.</p>
                     <p><strong>Source:</strong> Org chart or records.</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="turnover-rate">
                     <h4>Staff Turnover Rate</h4>
                     <p><strong>What:</strong> Annual employee departure (%).</p>
                     <p><strong>Why:</strong> Low turnover signals stability.</p>
                     <p><strong>Scenario:</strong> 5% turnover = stable team.</p>
                     <p><strong>Source:</strong> HR or payroll data.</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="eng-sales-ratio">
                     <h4>Engineering to Sales Ratio</h4>
                     <p><strong>What:</strong> Engineers vs. salespeople ratio.</p>
                     <p><strong>Why:</strong> Balances dev and sales efficiency.</p>
                     <p><strong>Scenario:</strong> 2.5:1 = tech-focused.</p>
                     <p><strong>Source:</strong> HR team records.</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="support-tickets">
                     <h4>Support Tickets per Month</h4>
                     <p><strong>What:</strong> Monthly customer support requests.</p>
                     <p><strong>Why:</strong> Fewer tickets = reliable product.</p>
                     <p><strong>Scenario:</strong> 100 tickets = moderate load.</p>
                     <p><strong>Source:</strong> Support tools (e.g., Zendesk).</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="support-rating">
                     <h4>Customer Support Rating</h4>
                     <p><strong>What:</strong> Customer rating of support (1-10).</p>
                     <p><strong>Why:</strong> High ratings show satisfaction.</p>
                     <p><strong>Scenario:</strong> 8/10 = strong support.</p>
                     <p><strong>Source:</strong> Support surveys.</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="headcount-growth">
                     <h4>Headcount Growth Rate</h4>
                     <p><strong>What:</strong> Annual staff growth (%).</p>
                     <p><strong>Why:</strong> Moderate growth shows ambition.</p>
@@ -920,7 +912,7 @@
                     <p><strong>Source:</strong> HR records comparison.</p>
                   </div>
                 </div>
-              </details>
+              </div>
             <div class="space-y-3">
               <div>
                 <label for="fte" class="block font-medium text-gray-700 mb-1">Full-Time Employees</label>
@@ -971,67 +963,66 @@
             <p class="text-gray-600 mb-4 text-sm">
               Provide legal and risk details.
             </p>
-              <details class="mt-4 rounded-lg bg-gray-50 p-4">
-                <summary class="cursor-pointer font-medium text-gray-800">Why these metrics matter</summary>
+              <div id="step-7-explanations" class="hidden hidden-explanations">
                 <p class="mt-3 text-gray-600 text-sm">Legal issues can lower valuation.</p>
                 <div class="explanation-section">
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="legal-entity">
                     <h4>Legal Entity Type</h4>
                     <p><strong>What:</strong> Business structure (e.g., LLC).</p>
                     <p><strong>Why:</strong> Impacts tax and liability.</p>
                     <p><strong>Scenario:</strong> C-Corp = investor-friendly.</p>
                     <p><strong>Source:</strong> Incorporation documents.</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="ip-ownership">
                     <h4>IP Ownership Status</h4>
                     <p><strong>What:</strong> Who owns intellectual property.</p>
                     <p><strong>Why:</strong> Full ownership boosts value.</p>
                     <p><strong>Scenario:</strong> Fully owned = no disputes.</p>
                     <p><strong>Source:</strong> Legal agreements.</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="contract-length">
                     <h4>Average Customer Contract Length</h4>
                     <p><strong>What:</strong> Typical contract duration.</p>
                     <p><strong>Why:</strong> Longer contracts = stable revenue.</p>
                     <p><strong>Scenario:</strong> 12 months = predictable cash flow.</p>
                     <p><strong>Source:</strong> CRM or contracts.</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="contract-value">
                     <h4>Average Contract Value (ACV)</h4>
                     <p><strong>What:</strong> Yearly contract revenue.</p>
                     <p><strong>Why:</strong> Higher ACV = more value.</p>
                     <p><strong>Scenario:</strong> $12K ACV = strong deals.</p>
                     <p><strong>Source:</strong> Billing systems.</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="vendor-lockin">
                     <h4>Vendor Lock-In</h4>
                     <p><strong>What:</strong> Customer reliance on your product.</p>
                     <p><strong>Why:</strong> High lock-in reduces churn.</p>
                     <p><strong>Scenario:</strong> High = sticky product.</p>
                     <p><strong>Source:</strong> Customer feedback or CRM.</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="legal-issues">
                     <h4>Pending Legal Issues</h4>
                     <p><strong>What:</strong> Ongoing lawsuits or disputes.</p>
                     <p><strong>Why:</strong> Issues lower valuation.</p>
                     <p><strong>Scenario:</strong> None = clean record.</p>
                     <p><strong>Source:</strong> Legal team.</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="data-privacy">
                     <h4>Data Privacy Compliance</h4>
                     <p><strong>What:</strong> Adherence to privacy laws.</p>
                     <p><strong>Why:</strong> Compliance reduces risks.</p>
                     <p><strong>Scenario:</strong> GDPR-compliant = safe.</p>
                     <p><strong>Source:</strong> Legal audits.</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="cyber-insurance">
                     <h4>Cybersecurity Insurance</h4>
                     <p><strong>What:</strong> Insurance for cyber risks.</p>
                     <p><strong>Why:</strong> Mitigates data breach costs.</p>
                     <p><strong>Scenario:</strong> Yes = risk-prepared.</p>
                     <p><strong>Source:</strong> Insurance policy.</p>
                   </div>
-                  <div class="explanation-box">
+                  <div class="explanation-box" data-for="debt-level">
                     <h4>Debt Level</h4>
                     <p><strong>What:</strong> Outstanding business debt.</p>
                     <p><strong>Why:</strong> High debt lowers valuation.</p>
@@ -1039,7 +1030,7 @@
                     <p><strong>Source:</strong> Financial statements.</p>
                   </div>
                 </div>
-              </details>
+              </div>
             <div class="space-y-3">
               <div>
                 <label for="legal-entity" class="block font-medium text-gray-700 mb-1">Legal Entity Type</label>

--- a/scripts/explanations.js
+++ b/scripts/explanations.js
@@ -1,0 +1,29 @@
+export function initExplanations() {
+  const boxes = document.querySelectorAll('.hidden-explanations .explanation-box');
+  boxes.forEach((box) => {
+    const targetId = box.dataset.for;
+    if (!targetId) return;
+    const target = document.getElementById(targetId);
+    if (!target) return;
+    const details = document.createElement('details');
+    details.className = 'mt-2 bg-gray-50 p-2 rounded';
+    const summary = document.createElement('summary');
+    summary.textContent = 'What does this mean?';
+    summary.className = 'cursor-pointer text-sm text-teal-600';
+    details.appendChild(summary);
+    const content = document.createElement('div');
+    // Clone children excluding the first heading
+    Array.from(box.children).forEach((child, index) => {
+      if (index === 0 && child.tagName && child.tagName.toLowerCase() === 'h4') return;
+      content.appendChild(child.cloneNode(true));
+    });
+    details.appendChild(content);
+    const container = target.closest('label') || target.parentElement;
+    if (container.tagName.toLowerCase() === 'label') {
+      container.insertAdjacentElement('afterend', details);
+    } else {
+      container.appendChild(details);
+    }
+  });
+  document.querySelectorAll('.hidden-explanations').forEach((sec) => sec.remove());
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,8 @@
 import { initNavigation } from './navigation.js';
 import * as validation from './validation.js';
 import { calculateValuation } from './valuation.js';
+import { initExplanations } from './explanations.js';
 
 validation.setupValidationListeners();
+initExplanations();
 initNavigation(validation, calculateValuation);


### PR DESCRIPTION
## Summary
- Inline per-question method explanations for valuation steps
- Add script to dynamically place explanations under inputs

## Testing
- `npm test`
- `npm run e2e` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_689fea016c5c832390e727ce93d5e568