### PR TITLE
Fix favicon links to relative paths

### DIFF
--- a/How-to-value-your-saas-company.html
+++ b/How-to-value-your-saas-company.html
@@ -11,12 +11,12 @@
       gtag('config', 'G-772JV93TYR');
     </script>
     <link rel="icon" type="image/png" href="favicon.png">
-    <link rel="icon" type="image/png" href="/http://saasvaluation.app/faivcon.png/favicon-96x96.png" sizes="96x96" />
-    <link rel="icon" type="image/svg+xml" href="/http://saasvaluation.app/faivcon.png/favicon.svg" />
-    <link rel="shortcut icon" href="/http://saasvaluation.app/faivcon.png/favicon.ico" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/http://saasvaluation.app/faivcon.png/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <link rel="shortcut icon" href="favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
     <meta name="apple-mobile-web-app-title" content="SaaS Val" />
-    <link rel="manifest" href="/http://saasvaluation.app/faivcon.png/site.webmanifest" />
+    <link rel="manifest" href="site.webmanifest" />
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Learn how to value your SaaS company with our comprehensive guide and free SaaS Valuation Calculator. Discover how to correctly value a SaaS company using key metrics and proven methods.">

--- a/blog.html
+++ b/blog.html
@@ -11,12 +11,12 @@
       gtag('config', 'G-772JV93TYR');
     </script>
     <link rel="icon" type="image/png" href="favicon.png">
-    <link rel="icon" type="image/png" href="/http://saasvaluation.app/faivcon.png/favicon-96x96.png" sizes="96x96" />
-    <link rel="icon" type="image/svg+xml" href="/http://saasvaluation.app/faivcon.png/favicon.svg" />
-    <link rel="shortcut icon" href="/http://saasvaluation.app/faivcon.png/favicon.ico" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/http://saasvaluation.app/faivcon.png/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <link rel="shortcut icon" href="favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
     <meta name="apple-mobile-web-app-title" content="SaaS Val" />
-    <link rel="manifest" href="/http://saasvaluation.app/faivcon.png/site.webmanifest" />
+    <link rel="manifest" href="site.webmanifest" />
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SaaS Valuation App - Blog | Insights on SaaS and Business Valuation</title>

--- a/boost-saas-revenue.html
+++ b/boost-saas-revenue.html
@@ -17,12 +17,12 @@
     <meta name="description" content="Optimize your SaaS pricing model in 2025 to maximize revenue with tiered pricing, value-based strategies, and data-driven insights for sustainable growth.">
     <meta name="keywords" content="SaaS pricing, tiered pricing, value-based pricing, revenue growth, churn reduction">
     <link rel="icon" type="image/png" href="favicon.png">
-<link rel="icon" type="image/png" href="/http://saasvaluation.app/faivcon.png/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/http://saasvaluation.app/faivcon.png/favicon.svg" />
-<link rel="shortcut icon" href="/http://saasvaluation.app/faivcon.png/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/http://saasvaluation.app/faivcon.png/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="favicon.svg" />
+<link rel="shortcut icon" href="favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
 <meta name="apple-mobile-web-app-title" content="SaaS Val" />
-<link rel="manifest" href="/http://saasvaluation.app/faivcon.png/site.webmanifest" />
+<link rel="manifest" href="site.webmanifest" />
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/due-diligence-checklist.html
+++ b/due-diligence-checklist.html
@@ -11,12 +11,12 @@
       gtag('config', 'G-772JV93TYR');
     </script>
     <link rel="icon" type="image/png" href="favicon.png">
-<link rel="icon" type="image/png" href="/http://saasvaluation.app/faivcon.png/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/http://saasvaluation.app/faivcon.png/favicon.svg" />
-<link rel="shortcut icon" href="/http://saasvaluation.app/faivcon.png/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/http://saasvaluation.app/faivcon.png/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="favicon.svg" />
+<link rel="shortcut icon" href="favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
 <meta name="apple-mobile-web-app-title" content="SaaS Val" />
-<link rel="manifest" href="/http://saasvaluation.app/faivcon.png/site.webmanifest" />
+<link rel="manifest" href="site.webmanifest" />
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Comprehensive Due Diligence Checklist for SaaS businesses to prepare for investor reviews or sales with SaaS Valuation App.">

--- a/free-valuation-calculator.html
+++ b/free-valuation-calculator.html
@@ -11,12 +11,12 @@
       gtag('config', 'G-772JV93TYR');
     </script>
     <link rel="icon" type="image/png" href="favicon.png">
-<link rel="icon" type="image/png" href="/http://saasvaluation.app/faivcon.png/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/http://saasvaluation.app/faivcon.png/favicon.svg" />
-<link rel="shortcut icon" href="/http://saasvaluation.app/faivcon.png/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/http://saasvaluation.app/faivcon.png/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="favicon.svg" />
+<link rel="shortcut icon" href="favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
 <meta name="apple-mobile-web-app-title" content="SaaS Val" />
-<link rel="manifest" href="/http://saasvaluation.app/faivcon.png/site.webmanifest" />
+<link rel="manifest" href="site.webmanifest" />
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Value your SaaS company for free with our Free SaaS Valuation Calculator. Get accurate business valuation in minutes. Try the Pro version for advanced insights.">

--- a/grow-tactics-for-2025.html
+++ b/grow-tactics-for-2025.html
@@ -17,12 +17,12 @@
     <meta name="description" content="Learn actionable tactics to scale your SaaS business in 2025, including market expansion, pricing strategies, team growth, and automation for sustainable success.">
     <meta name="keywords" content="SaaS growth, scale SaaS, market expansion, pricing strategies, team scaling, automation">
     <link rel="icon" type="image/png" href="favicon.png">
-<link rel="icon" type="image/png" href="/http://saasvaluation.app/faivcon.png/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/http://saasvaluation.app/faivcon.png/favicon.svg" />
-<link rel="shortcut icon" href="/http://saasvaluation.app/faivcon.png/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/http://saasvaluation.app/faivcon.png/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="favicon.svg" />
+<link rel="shortcut icon" href="favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
 <meta name="apple-mobile-web-app-title" content="SaaS Val" />
-<link rel="manifest" href="/http://saasvaluation.app/faivcon.png/site.webmanifest" />
+<link rel="manifest" href="site.webmanifest" />
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/how-to-value-saas.html
+++ b/how-to-value-saas.html
@@ -17,12 +17,12 @@
     <meta name="description" content="Learn how to value your SaaS business in 2025 with key metrics, valuation methods, and strategies to maximize your company's worth.">
     <meta name="keywords" content="SaaS valuation, business valuation, SaaS metrics, revenue multiples, churn rate, LTV/CAC">
     <link rel="icon" type="image/png" href="favicon.png">
-<link rel="icon" type="image/png" href="/http://saasvaluation.app/faivcon.png/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/http://saasvaluation.app/faivcon.png/favicon.svg" />
-<link rel="shortcut icon" href="/http://saasvaluation.app/faivcon.png/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/http://saasvaluation.app/faivcon.png/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="favicon.svg" />
+<link rel="shortcut icon" href="favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
 <meta name="apple-mobile-web-app-title" content="SaaS Val" />
-<link rel="manifest" href="/http://saasvaluation.app/faivcon.png/site.webmanifest" />
+<link rel="manifest" href="site.webmanifest" />
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -17,12 +17,12 @@
     <meta name="description" content="Read our privacy policy to learn how we handle user data and protect your information." />
     <meta name="keywords" content="privacy policy, data protection, user data" />
     <link rel="icon" type="image/png" href="favicon.png">
-<link rel="icon" type="image/png" href="/http://saasvaluation.app/faivcon.png/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/http://saasvaluation.app/faivcon.png/favicon.svg" />
-<link rel="shortcut icon" href="/http://saasvaluation.app/faivcon.png/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/http://saasvaluation.app/faivcon.png/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="favicon.svg" />
+<link rel="shortcut icon" href="favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
 <meta name="apple-mobile-web-app-title" content="SaaS Val" />
-<link rel="manifest" href="/http://saasvaluation.app/faivcon.png/site.webmanifest" />
+<link rel="manifest" href="site.webmanifest" />
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <style>

--- a/selling-your-small-business.html
+++ b/selling-your-small-business.html
@@ -17,12 +17,12 @@
     <meta name="description" content="Learn the essential steps to prepare and sell your small business, with expert tips to maximize value and streamline the sale process in 2025.">
     <meta name="keywords" content="sell small business, business sale, business valuation, business broker, due diligence">
     <link rel="icon" type="image/png" href="favicon.png">
-<link rel="icon" type="image/png" href="/http://saasvaluation.app/faivcon.png/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/http://saasvaluation.app/faivcon.png/favicon.svg" />
-<link rel="shortcut icon" href="/http://saasvaluation.app/faivcon.png/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/http://saasvaluation.app/faivcon.png/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="favicon.svg" />
+<link rel="shortcut icon" href="favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
 <meta name="apple-mobile-web-app-title" content="SaaS Val" />
-<link rel="manifest" href="/http://saasvaluation.app/faivcon.png/site.webmanifest" />
+<link rel="manifest" href="site.webmanifest" />
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/strategies-for-customer-retention.html
+++ b/strategies-for-customer-retention.html
@@ -17,12 +17,12 @@
     <meta name="description" content="Discover proven strategies to reduce SaaS churn in 2025, from enhancing onboarding to leveraging customer feedback for better retention.">
     <meta name="keywords" content="SaaS churn, customer retention, onboarding, customer feedback, proactive support">
     <link rel="icon" type="image/png" href="favicon.png">
-<link rel="icon" type="image/png" href="/http://saasvaluation.app/faivcon.png/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/http://saasvaluation.app/faivcon.png/favicon.svg" />
-<link rel="shortcut icon" href="/http://saasvaluation.app/faivcon.png/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/http://saasvaluation.app/faivcon.png/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="favicon.svg" />
+<link rel="shortcut icon" href="favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
 <meta name="apple-mobile-web-app-title" content="SaaS Val" />
-<link rel="manifest" href="/http://saasvaluation.app/faivcon.png/site.webmanifest" />
+<link rel="manifest" href="site.webmanifest" />
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/terms-and-conditions.html
+++ b/terms-and-conditions.html
@@ -12,12 +12,12 @@
   gtag('config', 'G-772JV93TYR');
 </script>
     <link rel="icon" type="image/png" href="favicon.png">
-<link rel="icon" type="image/png" href="/http://saasvaluation.app/faivcon.png/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/http://saasvaluation.app/faivcon.png/favicon.svg" />
-<link rel="shortcut icon" href="/http://saasvaluation.app/faivcon.png/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/http://saasvaluation.app/faivcon.png/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="favicon.svg" />
+<link rel="shortcut icon" href="favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
 <meta name="apple-mobile-web-app-title" content="SaaS Val" />
-<link rel="manifest" href="/http://saasvaluation.app/faivcon.png/site.webmanifest" />
+<link rel="manifest" href="site.webmanifest" />
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SaaS Valuation App - Terms and Conditions</title>

--- a/thank-you.html
+++ b/thank-you.html
@@ -17,12 +17,12 @@
   <meta name="description" content="View your SaaS valuation results and download your personalized report." />
   <meta name="keywords" content="valuation results, PDF report, SaaS appraisal" />
   <link rel="icon" type="image/png" href="favicon.png" />
-<link rel="icon" type="image/png" href="/http://saasvaluation.app/faivcon.png/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/http://saasvaluation.app/faivcon.png/favicon.svg" />
-<link rel="shortcut icon" href="/http://saasvaluation.app/faivcon.png/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/http://saasvaluation.app/faivcon.png/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="favicon.svg" />
+<link rel="shortcut icon" href="favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
 <meta name="apple-mobile-web-app-title" content="SaaS Val" />
-<link rel="manifest" href="/http://saasvaluation.app/faivcon.png/site.webmanifest" />
+<link rel="manifest" href="site.webmanifest" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>

--- a/valuation-guide.html
+++ b/valuation-guide.html
@@ -17,12 +17,12 @@
     <meta name="description" content="Step-by-step guide to valuing your SaaS company using proven metrics and valuation methods." />
     <meta name="keywords" content="SaaS valuation guide, how to value SaaS, valuation methods, SaaS metrics" />
     <link rel="icon" type="image/png" href="favicon.png">
-<link rel="icon" type="image/png" href="/http://saasvaluation.app/faivcon.png/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/http://saasvaluation.app/faivcon.png/favicon.svg" />
-<link rel="shortcut icon" href="/http://saasvaluation.app/faivcon.png/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/http://saasvaluation.app/faivcon.png/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="favicon.svg" />
+<link rel="shortcut icon" href="favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
 <meta name="apple-mobile-web-app-title" content="SaaS Val" />
-<link rel="manifest" href="/http://saasvaluation.app/faivcon.png/site.webmanifest" />
+<link rel="manifest" href="site.webmanifest" />
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <style>

--- a/valuing-ai-driven-trends.html
+++ b/valuing-ai-driven-trends.html
@@ -17,12 +17,12 @@
     <meta name="description" content="Discover the booming AI market and learn how proprietary technology, revenue growth, and scalability drive AI business valuations in 2025.">
     <meta name="keywords" content="AI market, AI valuation, business valuation, generative AI, proprietary technology">
     <link rel="icon" type="image/png" href="favicon.png">
-<link rel="icon" type="image/png" href="/http://saasvaluation.app/faivcon.png/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/http://saasvaluation.app/faivcon.png/favicon.svg" />
-<link rel="shortcut icon" href="/http://saasvaluation.app/faivcon.png/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/http://saasvaluation.app/faivcon.png/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="favicon.svg" />
+<link rel="shortcut icon" href="favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
 <meta name="apple-mobile-web-app-title" content="SaaS Val" />
-<link rel="manifest" href="/http://saasvaluation.app/faivcon.png/site.webmanifest" />
+<link rel="manifest" href="site.webmanifest" />
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
## Summary
- replace hard-coded `http://saasvaluation.app/faivcon.png` favicon URLs with relative paths
- verify icons served correctly

## Testing
- `curl -I http://localhost:3000/favicon-96x96.png`
- `curl -I http://localhost:3000/apple-touch-icon.png`
- `curl -I http://localhost:3000/site.webmanifest`
- `npm test`
- `npm run e2e` *(fails: process hangs even after installing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a257907ea08323a8fbc665ebb94978