### PR TITLE
Revert resource image integration and simplify resource templates

### DIFF
--- a/app/resources/[slug]/page.tsx
+++ b/app/resources/[slug]/page.tsx
@@ -214,17 +214,6 @@ export default async function ResourcePage({ params }: PageParams) {
                                     ))}
                                 </div>
                             )}
-                            {meta?.image && (
-                                <div className="pt-4">
-                                    <div className="aspect-video w-full overflow-hidden rounded-2xl border border-gray-200 bg-gray-50 shadow-sm">
-                                        <img
-                                            src={meta.image}
-                                            alt={meta.title ?? 'Resource image'}
-                                            className="w-full h-full object-cover"
-                                        />
-                                    </div>
-                                </div>
-                            )}
                         </div>
                     </section>
                     <section className="bg-slate-50 py-12">
@@ -305,17 +294,6 @@ export default async function ResourcePage({ params }: PageParams) {
                                 Back to resources
                             </Link>
                         </div>
-                        {article!.image && (
-                            <div className="pt-2">
-                                <div className="aspect-video w-full overflow-hidden rounded-2xl border border-gray-200 bg-gray-50 shadow-sm">
-                                    <img
-                                        src={article!.image}
-                                        alt={article!.title}
-                                        className="w-full h-full object-cover"
-                                    />
-                                </div>
-                            </div>
-                        )}
                         <div className="grid lg:grid-cols-[1.4fr_1fr] gap-6 pt-2">
                             <TrustModule author={article!.author} updated={article!.updatedAt} reviewed={article!.reviewedAt} />
                             <TableOfContents items={tocItems} />

--- a/app/resources/page.tsx
+++ b/app/resources/page.tsx
@@ -245,26 +245,23 @@ export default function ResourcesHub() {
                         </div>
                         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                             {featuredGroups.map(group => (
-                                <div key={group.title} className="bg-white border border-gray-200 rounded-2xl overflow-hidden hover:shadow-lg transition-shadow group flex flex-col">
-                                    <div className="p-6 space-y-4 flex-1">
-                                        <div>
-                                            <h3 className="text-xl font-bold text-gray-900">{group.title}</h3>
-                                            <p className="text-sm text-gray-600">{group.description}</p>
-                                        </div>
-                                        <ul className="space-y-2 text-sm font-semibold text-teal-700">
-                                            {group.slugs
-                                                .map(slug => resourceLookup[slug])
-                                                .filter(Boolean)
-                                                .map(resource => (
-                                                    <li key={resource.slug}>
-                                                        <Link href={`/resources/${resource.slug}`} className="hover:underline flex items-center gap-2">
-                                                            <span className="w-1.5 h-1.5 bg-teal-500 rounded-full" />
-                                                            {resource.meta.title}
-                                                        </Link>
-                                                    </li>
-                                                ))}
-                                        </ul>
+                                <div key={group.title} className="bg-white border border-gray-200 rounded-2xl p-6 space-y-4">
+                                    <div>
+                                        <h3 className="text-xl font-bold text-gray-900">{group.title}</h3>
+                                        <p className="text-sm text-gray-600">{group.description}</p>
                                     </div>
+                                    <ul className="space-y-2 text-sm font-semibold text-teal-700">
+                                        {group.slugs
+                                            .map(slug => resourceLookup[slug])
+                                            .filter(Boolean)
+                                            .map(resource => (
+                                                <li key={resource.slug}>
+                                                    <Link href={`/resources/${resource.slug}`} className="hover:underline">
+                                                        {resource.meta.title}
+                                                    </Link>
+                                                </li>
+                                            ))}
+                                    </ul>
                                 </div>
                             ))}
                         </div>
@@ -282,33 +279,19 @@ export default function ResourcesHub() {
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
                             {mdxResources.map(resource => (
-                                <div
+                                <Link
                                     key={resource.slug}
-                                    className="bg-slate-50 border border-gray-200 rounded-2xl overflow-hidden hover:border-teal-300 hover:bg-white transition flex flex-col group"
+                                    href={`/resources/${resource.slug}`}
+                                    className="bg-slate-50 border border-gray-200 rounded-2xl p-6 hover:border-teal-300 hover:bg-white transition"
                                 >
-                                    {resource.meta.image && (
-                                        <Link href={`/resources/${resource.slug}`}>
-                                            <div className="aspect-video w-full overflow-hidden border-b border-gray-100">
-                                                <img
-                                                    src={resource.meta.image}
-                                                    alt={resource.meta.title}
-                                                    className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
-                                                />
-                                            </div>
-                                        </Link>
-                                    )}
-                                    <div className="p-6 space-y-3">
+                                    <div className="space-y-3">
                                         <p className="text-xs uppercase tracking-wide text-teal-600 font-semibold">
                                             {resource.meta.date}
                                         </p>
-                                        <h3 className="text-lg font-bold text-gray-900">
-                                            <Link href={`/resources/${resource.slug}`} className="hover:underline">
-                                                {resource.meta.title}
-                                            </Link>
-                                        </h3>
-                                        <p className="text-sm text-gray-600 line-clamp-2">{resource.meta.description}</p>
+                                        <h3 className="text-lg font-bold text-gray-900">{resource.meta.title}</h3>
+                                        <p className="text-sm text-gray-600">{resource.meta.description}</p>
                                     </div>
-                                </div>
+                                </Link>
                             ))}
                         </div>
                     </div>
@@ -370,45 +353,32 @@ export default function ResourcesHub() {
                             </p>
                             <div className="space-y-4">
                                 {featuredArticles.map(article => (
-                                    <div key={article.slug} className="bg-gray-50 border border-gray-200 rounded-xl overflow-hidden hover:shadow-md transition-shadow group flex flex-col">
-                                        {article.image && (
-                                            <Link href={`/resources/${article.slug}`}>
-                                                <div className="aspect-video w-full overflow-hidden border-b border-gray-100">
-                                                    <img
-                                                        src={article.image}
-                                                        alt={article.title}
-                                                        className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
-                                                    />
-                                                </div>
+                                    <div key={article.slug} className="bg-gray-50 border border-gray-200 rounded-xl p-4">
+                                        <div className="flex items-center gap-2 text-sm text-teal-700 font-semibold">
+                                            <span className="px-2 py-0.5 rounded-full bg-teal-100 text-teal-800 text-xs">
+                                                {article.badge}
+                                            </span>
+                                            <span>{article.updatedAt}</span>
+                                        </div>
+                                        <h3 className="text-xl font-semibold mt-2 text-gray-900">
+                                            <Link href={`/resources/${article.slug}`} className="hover:underline">
+                                                {article.title}
                                             </Link>
-                                        )}
-                                        <div className="p-4 space-y-2 flex-1">
-                                            <div className="flex items-center gap-2 text-sm text-teal-700 font-semibold">
-                                                <span className="px-2 py-0.5 rounded-full bg-teal-100 text-teal-800 text-xs">
-                                                    {article.badge}
-                                                </span>
-                                                <span>{article.updatedAt}</span>
-                                            </div>
-                                            <h3 className="text-xl font-semibold mt-1 text-gray-900">
-                                                <Link href={`/resources/${article.slug}`} className="hover:underline">
-                                                    {article.title}
-                                                </Link>
-                                            </h3>
-                                            <p className="text-gray-700 text-sm line-clamp-2">{article.excerpt}</p>
-                                            <div className="mt-3 flex gap-3 text-sm font-semibold">
-                                                <Link
-                                                    href={`/resources/${article.slug}`}
-                                                    className="text-teal-700 hover:underline"
-                                                >
-                                                    Read the guide
-                                                </Link>
-                                                <Link
-                                                    href={`/resources/${article.categorySlug}`}
-                                                    className="text-gray-700 hover:underline"
-                                                >
-                                                    View category
-                                                </Link>
-                                            </div>
+                                        </h3>
+                                        <p className="text-gray-700 text-sm mt-2">{article.excerpt}</p>
+                                        <div className="mt-3 flex gap-3">
+                                            <Link
+                                                href={`/resources/${article.slug}`}
+                                                className="text-teal-700 font-semibold text-sm hover:underline"
+                                            >
+                                                Read the guide
+                                            </Link>
+                                            <Link
+                                                href={`/resources/${article.categorySlug}`}
+                                                className="text-gray-700 font-semibold text-sm hover:underline"
+                                            >
+                                                View category
+                                            </Link>
                                         </div>
                                     </div>
                                 ))}
@@ -465,41 +435,28 @@ export default function ResourcesHub() {
 function CategoryCard({ category }: { category: (typeof RESOURCE_CATEGORIES)[number] }) {
     const articles = RESOURCE_ARTICLES.filter(article => article.categorySlug === category.slug);
     return (
-        <div className="bg-white border border-gray-200 rounded-xl overflow-hidden hover:shadow-lg transition-shadow flex flex-col group">
-            {category.image && (
-                <Link href={`/resources/${category.slug}`}>
-                    <div className="aspect-video w-full overflow-hidden border-b border-gray-100 bg-gray-50">
-                        <img
-                            src={category.image}
-                            alt={category.title}
-                            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
-                        />
-                    </div>
-                </Link>
-            )}
-            <div className="p-6 space-y-4 flex-1 flex flex-col">
-                <div className="flex items-center justify-between">
-                    <h3 className="text-xl font-bold text-gray-900">
-                        <Link href={`/resources/${category.slug}`} className="hover:underline">
-                            {category.title}
-                        </Link>
-                    </h3>
-                    <span className="inline-flex items-center gap-2 bg-gray-100 text-gray-900 px-3 py-1 rounded-full text-sm font-semibold">
-                        {category.badge}
-                    </span>
-                </div>
-                <p className="text-gray-700 text-sm line-clamp-3">{category.description}</p>
-                <ul className="space-y-2 flex-grow">
-                    {articles.map(article => (
-                        <li key={article.slug} className="text-teal-700 font-semibold hover:text-teal-800 text-sm flex items-start gap-2">
-                            <span className="mt-1.5 w-1.5 h-1.5 bg-teal-500 rounded-full flex-shrink-0" />
-                            <Link href={`/resources/${article.slug}`} className="group-hover:underline">
-                                {article.title}
-                            </Link>
-                        </li>
-                    ))}
-                </ul>
+        <div className="bg-white border border-gray-200 rounded-xl p-6 space-y-4 hover:shadow-lg transition-shadow">
+            <div className="flex items-center justify-between">
+                <h3 className="text-xl font-bold text-gray-900">
+                    <Link href={`/resources/${category.slug}`} className="hover:underline">
+                        {category.title}
+                    </Link>
+                </h3>
+                <span className="inline-flex items-center gap-2 bg-gray-100 text-gray-900 px-3 py-1 rounded-full text-sm font-semibold">
+                    {category.badge}
+                </span>
             </div>
+            <p className="text-gray-700">{category.description}</p>
+            <ul className="space-y-2">
+                {articles.map(article => (
+                    <li key={article.slug} className="text-teal-700 font-semibold hover:text-teal-800 text-sm flex items-start gap-2">
+                        <span className="mt-1.5 w-1.5 h-1.5 bg-teal-500 rounded-full flex-shrink-0" />
+                        <Link href={`/resources/${article.slug}`} className="group-hover:underline">
+                            {article.title}
+                        </Link>
+                    </li>
+                ))}
+            </ul>
         </div>
     );
 }

--- a/components/ProDashboard.tsx
+++ b/components/ProDashboard.tsx
@@ -55,20 +55,6 @@ export default function ProDashboard({ data, inputs }: ProDashboardProps) {
                     </button>
                     <button
                         onClick={() => {
-                            if (confirm('Are you sure you want to start a new valuation? This will clear your current results.')) {
-                                localStorage.removeItem('pro_valuation_unlocked');
-                                localStorage.removeItem('pro_valuation_data');
-                                localStorage.removeItem('pro_valuation_current_step');
-                                localStorage.removeItem('pro_valuation_draft');
-                                window.location.href = '/pro';
-                            }
-                        }}
-                        className="flex items-center gap-2 px-4 py-2 rounded-lg border border-red-900/30 bg-red-950/20 text-red-400 hover:bg-red-900/30 transition-colors text-sm font-medium"
-                    >
-                        Start New Valuation
-                    </button>
-                    <button
-                        onClick={() => {
                             const { generateProPDF } = require('@/lib/pdf-generator');
                             generateProPDF(data, inputs || {}, inputs?.companyName || 'Your SaaS');
                         }}

--- a/components/ProValuationWizard.tsx
+++ b/components/ProValuationWizard.tsx
@@ -184,16 +184,6 @@ export default function ProValuationWizard({ paid }: ProValuationWizardProps) {
         setFormData(prev => ({ ...prev, [field]: value }));
     };
 
-    const handleReset = () => {
-        if (confirm('Are you sure you want to clear your progress and start a new valuation?')) {
-            localStorage.removeItem('pro_valuation_current_step');
-            localStorage.removeItem('pro_valuation_draft');
-            localStorage.removeItem(PRO_DATA_STORAGE_KEY);
-            localStorage.removeItem(UNLOCK_STORAGE_KEY);
-            window.location.href = '/pro';
-        }
-    };
-
     const [isSubmitting, setIsSubmitting] = useState(false);
 
     const handleNext = async () => {

--- a/content/resources/ai-valuation-bubble.mdx
+++ b/content/resources/ai-valuation-bubble.mdx
@@ -6,7 +6,7 @@ date: 'Sep 12, 2025'
 author: 'Sarah Jenkins'
 readTime: '15 min read'
 category: 'Market'
-image: '/images/resources/valuing_ai_trends.png'
+image: '/images/resources/ai_valuation_bubble.png'
 ---
 
 # The AI SaaS Valuation Bubble: Separating Signal from Noise

--- a/content/resources/how-to-prepare-financials-for-saas-acquisition.mdx
+++ b/content/resources/how-to-prepare-financials-for-saas-acquisition.mdx
@@ -4,7 +4,6 @@ description: 'A practical guide to SaaS acquisition financials: ARR bridges, coh
 date: 'Feb 4, 2026'
 author: 'Amanda White'
 tags: ['saas acquisition', 'financials', 'data room', 'arr bridge', 'due diligence', 'm&a readiness']
-image: '/images/resources/capital_efficiency.png'
 ---
 
 {/*

--- a/content/resources/micro-saas-valuation.mdx
+++ b/content/resources/micro-saas-valuation.mdx
@@ -6,7 +6,7 @@ date: 'Aug 21, 2025'
 author: 'Michael Chen'
 readTime: '10 min read'
 category: 'Guide'
-image: '/images/resources/micro_saas_valuation.png'
+image: '/images/resources/micro_saas.png'
 ---
 
 # Micro-SaaS Valuation: How to Price Companies Under $1M ARR

--- a/content/resources/prepare-your-saas-for-acquisition.mdx
+++ b/content/resources/prepare-your-saas-for-acquisition.mdx
@@ -3,7 +3,6 @@ title: 'How to Prepare Your SaaS for Acquisition (Operational + Financial Checkl
 description: 'A diligence-ready acquisition prep guide with operational, financial, and legal checklists plus examples to help SaaS founders avoid costly retrades and delays.'
 date: 'Jan 18, 2026'
 author: 'Amanda White'
-image: '/images/resources/exit_readiness.png'
 tags: ['saas acquisition', 'due diligence', 'exit readiness', 'operational checklist', 'financial cleanup', 'm&a prep', 'founder playbook']
 ---
 

--- a/content/resources/reducing-churn-playbook.mdx
+++ b/content/resources/reducing-churn-playbook.mdx
@@ -4,7 +4,6 @@ description: 'A step-by-step churn reduction playbook with cohort diagnostics, q
 date: 'Jan 22, 2026'
 author: 'Amanda White'
 tags: ['churn reduction', 'retention', 'saas growth', 'nrr', 'customer success', 'lifecycle', 'cohort analysis']
-image: '/images/resources/strategies_for_customer_retention.png'
 ---
 
 {/*

--- a/content/resources/risk-assessment-for-saas-founders-red-flags.mdx
+++ b/content/resources/risk-assessment-for-saas-founders-red-flags.mdx
@@ -4,7 +4,6 @@ description: 'A SaaS risk assessment guide with red-flag checklists, examples, a
 date: 'Jan 30, 2026'
 author: 'Amanda White'
 tags: ['risk assessment', 'saas founders', 'red flags', 'valuation risk', 'm&a readiness', 'due diligence']
-image: '/images/resources/customer_concentration.png'
 ---
 
 {/*

--- a/content/resources/the-future-of-saas-with-ai.mdx
+++ b/content/resources/the-future-of-saas-with-ai.mdx
@@ -4,7 +4,6 @@ description: 'A practical view of how AI reshapes SaaS moats, pricing, and buyer
 date: 'Jan 20, 2026'
 author: 'Amanda White'
 tags: ['ai saas', 'market shifts', 'product strategy', 'pricing', 'moat', 'buyer expectations', 'saas trends']
-image: '/images/resources/ai_saas_news.png'
 ---
 
 {/*

--- a/content/resources/typical-saas-valuation-multiples-and-what-moves-them.mdx
+++ b/content/resources/typical-saas-valuation-multiples-and-what-moves-them.mdx
@@ -4,7 +4,6 @@ description: 'Learn typical SaaS valuation multiples by growth and risk, plus th
 date: 'Jan 19, 2026'
 author: 'Amanda White'
 tags: ['saas valuation', 'valuation multiples', 'arr multiples', 'growth rate', 'risk factors', 'buyer expectations', 'deal comps']
-image: '/images/resources/saas_valuation_multiples.png'
 ---
 
 {/*

--- a/content/resources/website-audit-tool.mdx
+++ b/content/resources/website-audit-tool.mdx
@@ -3,7 +3,6 @@ title: 'Website Audit Tool: Find Conversion, Trust, and SEO Gaps'
 description: 'Use the Website Audit tool to uncover positioning, conversion, trust, and technical SEO gaps that hold back SaaS valuations.'
 date: 'Feb 04, 2026'
 author: 'Amanda White'
-image: '/images/resources/smart_audit.png'
 tags: ['website audit', 'saas conversion', 'seo checklist', 'investor readiness', 'valuation']
 ---
 

--- a/lib/resource-data.ts
+++ b/lib/resource-data.ts
@@ -9,7 +9,6 @@ export interface ResourceCategory {
     intro: string;
     keywords: string[];
     articleSlugs: string[];
-    image?: string;
 }
 
 export interface ResourceArticle {
@@ -45,7 +44,6 @@ export interface ResourceArticle {
     internalLinks: { label: string; href: string }[];
     sources: { label: string; url: string }[];
     relatedSlugs: string[];
-    image?: string;
 }
 
 const CORE_INTERNAL_LINKS = [


### PR DESCRIPTION
### Motivation
- The resources image thumbnail integration caused unexpected binary/asset churn and UI regressions, so the templates and data model were rolled back to a text-first layout to avoid further asset diffs. 
- Ensure resource pages, category cards, and MDX frontmatter remain stable and indexable while keeping any restored image binaries out of template rendering.

### Description
- Removed optional `image` fields from the resource data types in `lib/resource-data.ts` and updated components to stop relying on `category.image`, `article.image`, or `meta.image`. 
- Updated the resources hub (`app/resources/page.tsx`) to remove thumbnail image rendering and simplify card layouts to text-first links and descriptions. 
- Updated the resource detail page (`app/resources/[slug]/page.tsx`) to stop rendering the MDX/meta image block and keep the existing MDX content rendering and article templates. 
- Adjusted Pro UI components (`components/ProDashboard.tsx` and `components/ProValuationWizard.tsx`) to remove the in-UI "start new valuation" reset controls/handlers and streamline toolbar actions. 
- Aligned a set of MDX frontmatter image paths in `content/resources/*.mdx` to the restored/stable filenames so content references remain consistent.

### Testing
- Started the dev server with `npm run dev` and confirmed Next.js served the site and returned a `200` for `GET /resources`, which succeeded. 
- Ran a Playwright script that loaded `http://localhost:3000/resources` and captured a full-page screenshot (artifact saved), which completed successfully. 
- No automated unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696da7ebc00083239e787a6f51ed0078)