### PR TITLE
Use existing resource images to avoid binary assets

### DIFF
--- a/content/resources/ai-first-saas-moat-defensibility-and-pricing.mdx
+++ b/content/resources/ai-first-saas-moat-defensibility-and-pricing.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'AI-First SaaS: Moat, Defensibility, and Pricing Strategy'
 description: 'A founder playbook for AI-first SaaS: build a defensible moat, price on outcomes, and communicate value to buyers and investors.'
+image: '/images/resources/valuing_ai_trends.png'
 date: 'Jan 21, 2026'
 author: 'Amanda White'
 tags: ['ai saas', 'moat', 'pricing strategy', 'defensibility', 'outcome metrics', 'product strategy', 'valuation narrative']

--- a/content/resources/nrr-mastery.mdx
+++ b/content/resources/nrr-mastery.mdx
@@ -6,7 +6,7 @@ date: 'Dec 1, 2025'
 author: 'Amanda White'
 readTime: '10 min read'
 category: 'Metrics'
-image: '/images/resources/growth_metrics.png'
+image: '/images/resources/capital_efficiency.png'
 ---
 
 # NRR Mastery: Why Net Revenue Retention Wins Exits
@@ -137,5 +137,3 @@ A: No! Net *Revenue* Retention is about the *Retained* cohort. Do not include ne
 *   [Growth Metrics](/resources/growth-metrics) - Broader KPI list including CAC and LTV.
 *   [Valuation Guide](/resources/how-to-value-saas) - Impact on exit price.
 *   [Rule of 40](/resources/rule-of-40) - The efficiency metric.
-
-

--- a/content/resources/reducing-churn-playbook.mdx
+++ b/content/resources/reducing-churn-playbook.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Reducing Churn: A Practical SaaS Playbook'
 description: 'A step-by-step churn reduction playbook with cohort diagnostics, quick wins, and retention experiments you can run in the next 60 days.'
+image: '/images/resources/strategies_for_customer_retention.png'
 date: 'Jan 22, 2026'
 author: 'Amanda White'
 tags: ['churn reduction', 'retention', 'saas growth', 'nrr', 'customer success', 'lifecycle', 'cohort analysis']

--- a/content/resources/saas-onboarding-that-improves-retention.mdx
+++ b/content/resources/saas-onboarding-that-improves-retention.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'SaaS Onboarding That Improves Retention'
 description: 'Design onboarding that drives activation and retention with milestone-based flows, success triggers, and real examples for SaaS teams.'
+image: '/images/resources/customer_concentration.png'
 date: 'Jan 23, 2026'
 author: 'Amanda White'
 tags: ['saas onboarding', 'activation', 'retention', 'customer success', 'product-led growth', 'churn reduction']

--- a/content/resources/saas-pricing-strategies-value-vs-usage-vs-tiers.mdx
+++ b/content/resources/saas-pricing-strategies-value-vs-usage-vs-tiers.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'SaaS Pricing Strategies: Value vs Usage vs Tiers'
 description: 'Compare value-based, usage-based, and tiered pricing for SaaS with decision frameworks, examples, and metrics that guide the right model.'
+image: '/images/resources/saas_valuation_multiples.png'
 date: 'Jan 24, 2026'
 author: 'Amanda White'
 tags: ['saas pricing', 'value-based pricing', 'usage-based pricing', 'tiered pricing', 'unit economics', 'growth strategy']

--- a/content/resources/the-future-of-saas-with-ai.mdx
+++ b/content/resources/the-future-of-saas-with-ai.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'The Future of SaaS with AI: What Founders Should Plan For'
 description: 'A practical view of how AI reshapes SaaS moats, pricing, and buyer expectations, with scenarios, risks, and actions for 2026 plans.'
+image: '/images/resources/ai_saas_news.png'
 date: 'Jan 20, 2026'
 author: 'Amanda White'
 tags: ['ai saas', 'market shifts', 'product strategy', 'pricing', 'moat', 'buyer expectations', 'saas trends']


### PR DESCRIPTION
### Motivation
- The repository rejected new binary PNG assets, so articles were updated to reference existing images instead of adding new binaries.
- Prevent future binary-asset churn and keep the `public/images/resources/` directory consistent by reusing available assets.

### Description
- Updated frontmatter `image` references in ten resource articles (e.g. `free-valuation-calculator.mdx`, `growth-metrics.mdx`, `micro-saas-valuation.mdx`, `nrr-mastery.mdx`, `rule-of-40.mdx`, `reducing-churn-playbook.mdx`, `ai-first-saas-moat-defensibility-and-pricing.mdx`, `the-future-of-saas-with-ai.mdx`, `saas-onboarding-that-improves-retention.mdx`, and `saas-pricing-strategies-value-vs-usage-vs-tiers.mdx`) to point at existing files in `public/images/resources/`.
- Removed the ten newly generated PNG files from `public/images/resources/` to avoid adding unsupported binary files.
- Committed the updated MDX files and file deletions so the site uses the existing image assets.

### Testing
- Started the local dev server with `npm run dev`, and Next.js compiled the `/resources` page and served `GET /resources` with HTTP 200 successfully.
- An attempted Playwright screenshot of `/resources` timed out and did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e20950e5c8323b01ce8c49db00691)