### PR TITLE
Add AdSense verification script to layout head

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,6 +25,15 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <Script
+          id="adsense-script"
+          async
+          strategy="beforeInteractive"
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6483721386563068"
+          crossOrigin="anonymous"
+        />
+      </head>
       <body className={`${inter.variable} ${outfit.variable} antialiased bg-slate-950 text-slate-100 font-sans`}>
         {children}
         <CookieConsentBanner />


### PR DESCRIPTION
### Motivation
- Ensure Google AdSense can verify the site by loading the required AdSense script in the document head so verification detects the snippet.

### Description
- Inserted a Next.js `Script` in `app/layout.tsx` inside a `<head>` element with `id="adsense-script"`, `async`, `strategy="beforeInteractive"`, `src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6483721386563068"`, and `crossOrigin="anonymous"`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e892ebb348323bf6692f8a69f2f5e)